### PR TITLE
feat: 쪽지시험 목록 페이지 구현 (#2)

### DIFF
--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -31,7 +31,7 @@ const variantClasses: Record<ButtonVariant, string> = {
 
 const sizeClasses: Record<ButtonSize, string> = {
   sm: 'h-9 px-3 text-sm font-medium rounded-sm gap-1.5',
-  md: 'h-12 px-5 text-base font-medium rounded-sm gap-2',
+  md: 'h-12 px-5 text-base font-semibold leading-[140%] tracking-[-0.03em] rounded-sm gap-2',
   lg: 'h-14 px-6 text-lg font-semibold rounded-sm gap-2',
 }
 

--- a/src/components/mypage/MypageLayout/MypageLayout.tsx
+++ b/src/components/mypage/MypageLayout/MypageLayout.tsx
@@ -1,4 +1,4 @@
-import { Outlet, useLocation, useNavigate } from 'react-router'
+import { Outlet } from 'react-router'
 import { ROUTES } from '@/constants/routes'
 import { SidebarTab } from '@/components/mypage/SidebarTab'
 
@@ -9,20 +9,13 @@ const navItems = [
 ]
 
 export function MypageLayout() {
-  const location = useLocation()
-  const navigate = useNavigate()
-
   return (
     <div className="mx-auto w-[944px] py-[108px]">
       <div className="flex gap-12">
         {/* 사이드바 */}
         <nav className="flex shrink-0 flex-col gap-4">
           {navItems.map(({ label, to }) => (
-            <SidebarTab
-              key={to}
-              isActive={location.pathname === to}
-              onClick={() => navigate(to)}
-            >
+            <SidebarTab key={to} to={to}>
               {label}
             </SidebarTab>
           ))}

--- a/src/components/mypage/MypageLayout/MypageLayout.tsx
+++ b/src/components/mypage/MypageLayout/MypageLayout.tsx
@@ -1,0 +1,38 @@
+import { Outlet, useLocation, useNavigate } from 'react-router'
+import { ROUTES } from '@/constants/routes'
+import { SidebarTab } from '@/components/mypage/SidebarTab'
+
+const navItems = [
+  { label: '내 정보', to: ROUTES.MYPAGE.HOME },
+  { label: '쪽지시험', to: ROUTES.MYPAGE.QUIZ },
+  { label: '비밀번호 변경', to: ROUTES.MYPAGE.CHANGE_PASSWORD },
+]
+
+export function MypageLayout() {
+  const location = useLocation()
+  const navigate = useNavigate()
+
+  return (
+    <div className="mx-auto w-[944px] py-[108px]">
+      <div className="flex gap-12">
+        {/* 사이드바 */}
+        <nav className="flex shrink-0 flex-col gap-4">
+          {navItems.map(({ label, to }) => (
+            <SidebarTab
+              key={to}
+              isActive={location.pathname === to}
+              onClick={() => navigate(to)}
+            >
+              {label}
+            </SidebarTab>
+          ))}
+        </nav>
+
+        {/* 메인 콘텐츠 */}
+        <div className="flex-1">
+          <Outlet />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/mypage/MypageLayout/index.ts
+++ b/src/components/mypage/MypageLayout/index.ts
@@ -1,2 +1,1 @@
 export { MypageLayout } from './MypageLayout'
-export { SidebarTab } from './SidebarTab'

--- a/src/components/mypage/SidebarTab/SidebarTab.tsx
+++ b/src/components/mypage/SidebarTab/SidebarTab.tsx
@@ -1,35 +1,41 @@
+import { NavLink } from 'react-router'
+
 interface SidebarTabProps {
   children: React.ReactNode
-  isActive?: boolean
+  to: string
   disabled?: boolean
-  onClick?: () => void
 }
 
 export function SidebarTab({
   children,
-  isActive = false,
+  to,
   disabled = false,
-  onClick,
 }: SidebarTabProps) {
   return (
-    <button
-      onClick={onClick}
-      disabled={disabled}
-      className={[
-        'relative flex h-8 w-[152px] items-center rounded-sm px-5 text-lg leading-normal tracking-[-0.03em] transition-colors duration-150',
-        isActive
-          ? 'text-primary font-semibold'
-          : disabled
-            ? 'bg-disable text-text-muted cursor-not-allowed font-normal'
-            : 'hover:text-primary hover:bg-primary-100 text-text-muted cursor-pointer font-normal hover:font-semibold',
-      ]
-        .filter(Boolean)
-        .join(' ')}
+    <NavLink
+      to={to}
+      end
+      className={({ isActive }) =>
+        [
+          'relative flex h-8 w-[152px] items-center rounded-sm px-5 text-lg leading-normal tracking-[-0.03em] transition-colors duration-150',
+          isActive
+            ? 'text-primary font-semibold'
+            : disabled
+              ? 'bg-disable text-text-muted cursor-not-allowed font-normal'
+              : 'hover:text-primary hover:bg-primary-100 text-text-muted cursor-pointer font-normal hover:font-semibold',
+        ]
+          .filter(Boolean)
+          .join(' ')
+      }
     >
-      {isActive && (
-        <span className="bg-primary absolute top-1/2 left-0 h-full w-0.5 -translate-y-1/2 rounded-full" />
+      {({ isActive }) => (
+        <>
+          {isActive && (
+            <span className="bg-primary absolute top-1/2 left-0 h-full w-0.5 -translate-y-1/2 rounded-full" />
+          )}
+          {children}
+        </>
       )}
-      {children}
-    </button>
+    </NavLink>
   )
 }

--- a/src/components/mypage/SidebarTab/SidebarTab.tsx
+++ b/src/components/mypage/SidebarTab/SidebarTab.tsx
@@ -1,0 +1,35 @@
+interface SidebarTabProps {
+  children: React.ReactNode
+  isActive?: boolean
+  disabled?: boolean
+  onClick?: () => void
+}
+
+export function SidebarTab({
+  children,
+  isActive = false,
+  disabled = false,
+  onClick,
+}: SidebarTabProps) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={[
+        'relative flex h-8 w-[152px] items-center rounded-sm px-5 text-lg leading-normal tracking-[-0.03em] transition-colors duration-150',
+        isActive
+          ? 'text-primary font-semibold'
+          : disabled
+            ? 'bg-disable text-text-muted cursor-not-allowed font-normal'
+            : 'hover:text-primary hover:bg-primary-100 text-text-muted cursor-pointer font-normal hover:font-semibold',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      {isActive && (
+        <span className="bg-primary absolute top-1/2 left-0 h-full w-0.5 -translate-y-1/2 rounded-full" />
+      )}
+      {children}
+    </button>
+  )
+}

--- a/src/components/mypage/SidebarTab/index.ts
+++ b/src/components/mypage/SidebarTab/index.ts
@@ -1,0 +1,1 @@
+export { SidebarTab } from './SidebarTab'

--- a/src/components/quiz/QuizCard/QuizCard.tsx
+++ b/src/components/quiz/QuizCard/QuizCard.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router'
+import { useNavigate } from 'react-router'
 import { Button } from '@/components/common/Button'
 import { ROUTES } from '@/constants/routes'
 import type { DeploymentListItem } from '@/features/exams/deployments'
@@ -11,7 +11,7 @@ function StatusBadge({ isDone }: { isDone: boolean }) {
   return (
     <span
       className={[
-        'inline-flex h-6 items-center rounded-sm px-2 text-xs leading-normal font-normal tracking-[-0.03em]',
+        'inline-flex h-6 items-center rounded-sm px-2 text-xs leading-[140%] font-normal tracking-[-0.03em]',
         isDone
           ? 'bg-success-bg text-success-dark'
           : 'bg-error-bg text-error-dark',
@@ -23,11 +23,12 @@ function StatusBadge({ isDone }: { isDone: boolean }) {
 }
 
 export function QuizCard({ item }: QuizCardProps) {
+  const navigate = useNavigate()
   const { id, exam, exam_info, question_count, total_score } = item
   const isDone = exam_info.status === 'done'
 
   const subtitle = isDone
-    ? `${exam.subject.title} · ${exam_info.score}점/${total_score}점 · ${exam_info.correct_answer_count}/${question_count}개 정답`
+    ? `${exam.subject.title} · ${exam_info.score ?? 0}점/${total_score}점 · ${exam_info.correct_answer_count ?? 0}/${question_count}개 정답`
     : `${exam.subject.title} · 응시하고 점수를 확인해보세요!`
 
   return (
@@ -38,30 +39,39 @@ export function QuizCard({ item }: QuizCardProps) {
           <img
             src={exam.thumbnail_img_url}
             alt={exam.title}
+            width={28}
+            height={28}
             className="h-full w-full object-contain"
           />
         </div>
         <div className="flex flex-col justify-center gap-1">
           <div className="flex items-center gap-3">
-            <span className="font-semibold text-black">{exam.title}</span>
+            <span className="text-lg leading-[140%] font-semibold tracking-[-0.03em] text-black">
+              {exam.title}
+            </span>
             <StatusBadge isDone={isDone} />
           </div>
-          <span className="text-sm text-gray-700">{subtitle}</span>
+          <span className="text-sm leading-[140%] tracking-[-0.03em] text-gray-700">
+            {subtitle}
+          </span>
         </div>
       </div>
 
       {/* 우측: CTA 버튼 */}
-      <Link
-        to={
-          isDone
-            ? ROUTES.QUIZ.RESULT.replace(':quizId', String(id))
-            : ROUTES.QUIZ.EXAM.replace(':quizId', String(id))
+      <Button
+        variant="outline"
+        size="md"
+        className="w-[112px]"
+        onClick={() =>
+          navigate(
+            isDone
+              ? ROUTES.QUIZ.RESULT.replace(':quizId', String(id))
+              : ROUTES.QUIZ.EXAM.replace(':quizId', String(id))
+          )
         }
       >
-        <Button variant="outline" size="md" className="w-[112px]">
-          {isDone ? '상세보기' : '응시하기'}
-        </Button>
-      </Link>
+        {isDone ? '상세보기' : '응시하기'}
+      </Button>
     </div>
   )
 }

--- a/src/components/quiz/QuizCard/QuizCard.tsx
+++ b/src/components/quiz/QuizCard/QuizCard.tsx
@@ -1,0 +1,67 @@
+import { Link } from 'react-router'
+import { Button } from '@/components/common/Button'
+import { ROUTES } from '@/constants/routes'
+import type { DeploymentListItem } from '@/features/exams/deployments'
+
+interface QuizCardProps {
+  item: DeploymentListItem
+}
+
+function StatusBadge({ isDone }: { isDone: boolean }) {
+  return (
+    <span
+      className={[
+        'inline-flex h-6 items-center rounded-sm px-2 text-xs leading-normal font-normal tracking-[-0.03em]',
+        isDone
+          ? 'bg-success-bg text-success-dark'
+          : 'bg-error-bg text-error-dark',
+      ].join(' ')}
+    >
+      {isDone ? '응시완료' : '미응시'}
+    </span>
+  )
+}
+
+export function QuizCard({ item }: QuizCardProps) {
+  const { id, exam, exam_info, question_count, total_score } = item
+  const isDone = exam_info.status === 'done'
+
+  const subtitle = isDone
+    ? `${exam.subject.title} · ${exam_info.score}점/${total_score}점 · ${exam_info.correct_answer_count}/${question_count}개 정답`
+    : `${exam.subject.title} · 응시하고 점수를 확인해보세요!`
+
+  return (
+    <div className="border-disable flex h-[104px] w-full items-center justify-between rounded-lg border bg-gray-100 px-8 py-7">
+      {/* 좌측: 아이콘 + 시험 정보 */}
+      <div className="flex items-center gap-4">
+        <div className="bg-primary-100 flex h-12 w-12 shrink-0 items-center justify-center p-[10px]">
+          <img
+            src={exam.thumbnail_img_url}
+            alt={exam.title}
+            className="h-full w-full object-contain"
+          />
+        </div>
+        <div className="flex flex-col justify-center gap-1">
+          <div className="flex items-center gap-3">
+            <span className="font-semibold text-black">{exam.title}</span>
+            <StatusBadge isDone={isDone} />
+          </div>
+          <span className="text-sm text-gray-700">{subtitle}</span>
+        </div>
+      </div>
+
+      {/* 우측: CTA 버튼 */}
+      <Link
+        to={
+          isDone
+            ? ROUTES.QUIZ.RESULT.replace(':quizId', String(id))
+            : ROUTES.QUIZ.EXAM.replace(':quizId', String(id))
+        }
+      >
+        <Button variant="outline" size="md" className="w-[112px]">
+          {isDone ? '상세보기' : '응시하기'}
+        </Button>
+      </Link>
+    </div>
+  )
+}

--- a/src/components/quiz/QuizCard/index.ts
+++ b/src/components/quiz/QuizCard/index.ts
@@ -1,0 +1,1 @@
+export { QuizCard } from './QuizCard'

--- a/src/components/quiz/QuizCardSkeleton/QuizCardSkeleton.tsx
+++ b/src/components/quiz/QuizCardSkeleton/QuizCardSkeleton.tsx
@@ -1,0 +1,28 @@
+function SkeletonBox({ className = '' }: { className?: string }) {
+  return (
+    <div
+      className={['animate-pulse rounded-sm bg-gray-200', className].join(' ')}
+    />
+  )
+}
+
+export function QuizCardSkeleton() {
+  return (
+    <div className="border-disable flex h-[104px] w-full items-center justify-between rounded-lg border bg-gray-100 px-8 py-7">
+      {/* 좌측: 아이콘 + 시험 정보 */}
+      <div className="flex items-center gap-4">
+        <SkeletonBox className="h-12 w-12 shrink-0" />
+        <div className="flex flex-col justify-center gap-2">
+          <div className="flex items-center gap-3">
+            <SkeletonBox className="h-4 w-36" />
+            <SkeletonBox className="h-6 w-14" />
+          </div>
+          <SkeletonBox className="h-3 w-56" />
+        </div>
+      </div>
+
+      {/* 우측: 버튼 */}
+      <SkeletonBox className="h-9 w-[112px]" />
+    </div>
+  )
+}

--- a/src/components/quiz/QuizCardSkeleton/index.ts
+++ b/src/components/quiz/QuizCardSkeleton/index.ts
@@ -1,0 +1,1 @@
+export { QuizCardSkeleton } from './QuizCardSkeleton'

--- a/src/components/quiz/QuizList/QuizList.tsx
+++ b/src/components/quiz/QuizList/QuizList.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from 'react'
 import { Spinner } from '@/components'
 import { QuizCard } from '@/components/quiz/QuizCard'
 import { useDeployments } from '@/features/exams/deployments'
@@ -15,14 +14,10 @@ export function QuizList({ params }: QuizListProps) {
 
   const items = data.pages.flatMap((page) => page.results)
 
-  const handleIntersect = useCallback(() => {
-    if (hasNextPage && !isFetchingNextPage) {
-      fetchNextPage()
-    }
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage])
-
   const sentinelRef = useIntersectionObserver({
-    onIntersect: handleIntersect,
+    onIntersect: () => {
+      if (hasNextPage && !isFetchingNextPage) fetchNextPage()
+    },
     enabled: hasNextPage,
   })
 

--- a/src/components/quiz/QuizList/QuizList.tsx
+++ b/src/components/quiz/QuizList/QuizList.tsx
@@ -1,0 +1,52 @@
+import { useCallback } from 'react'
+import { Spinner } from '@/components'
+import { QuizCard } from '@/components/quiz/QuizCard'
+import { useDeployments } from '@/features/exams/deployments'
+import { useIntersectionObserver } from '@/hooks/useIntersectionObserver'
+import type { DeploymentsParams } from '@/features/exams/deployments'
+
+interface QuizListProps {
+  params: Omit<DeploymentsParams, 'page'>
+}
+
+export function QuizList({ params }: QuizListProps) {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useDeployments(params)
+
+  const items = data.pages.flatMap((page) => page.results)
+
+  const handleIntersect = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage()
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage])
+
+  const sentinelRef = useIntersectionObserver({
+    onIntersect: handleIntersect,
+    enabled: hasNextPage,
+  })
+
+  if (items.length === 0) {
+    return (
+      <p className="py-20 text-center text-sm text-gray-500">
+        쪽지시험 목록이 없습니다.
+      </p>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {items.map((item) => (
+        <QuizCard key={item.id} item={item} />
+      ))}
+
+      <div ref={sentinelRef} className="h-1" />
+
+      {isFetchingNextPage && (
+        <div className="flex justify-center py-4">
+          <Spinner />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/quiz/QuizList/index.ts
+++ b/src/components/quiz/QuizList/index.ts
@@ -1,0 +1,1 @@
+export { QuizList } from './QuizList'

--- a/src/components/quiz/QuizListErrorBoundary/QuizListErrorBoundary.tsx
+++ b/src/components/quiz/QuizListErrorBoundary/QuizListErrorBoundary.tsx
@@ -1,0 +1,48 @@
+import { ErrorBoundary } from 'react-error-boundary'
+import { ErrorFallback } from '@/components/common/ErrorFallback'
+import { HTTP_STATUS } from '@/constants/httpStatus'
+import { useToastStore } from '@/stores/toastStore'
+import { getErrorStatus } from '@/utils/getErrorStatus'
+
+const ERROR_MESSAGES: Record<number, string> = {
+  [HTTP_STATUS.FORBIDDEN]: '조회 권한이 없습니다.',
+  [HTTP_STATUS.NOT_FOUND]: '결과를 찾을 수 없습니다.',
+}
+
+function handleError(error: unknown) {
+  const status = getErrorStatus(error)
+  if (!status || status >= HTTP_STATUS.INTERNAL_SERVER_ERROR) {
+    useToastStore
+      .getState()
+      .show('일시적인 오류가 발생했습니다. 다시 시도해주세요.', 'error')
+  }
+}
+
+export function QuizListErrorBoundary({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <ErrorBoundary
+      fallbackRender={({ error, resetErrorBoundary }) => {
+        const status = getErrorStatus(error)
+        return (
+          <ErrorFallback
+            message={
+              ERROR_MESSAGES[status ?? 0] ?? '알 수 없는 오류가 발생했습니다.'
+            }
+            onRetry={
+              !status || status >= HTTP_STATUS.INTERNAL_SERVER_ERROR
+                ? resetErrorBoundary
+                : undefined
+            }
+          />
+        )
+      }}
+      onError={handleError}
+    >
+      {children}
+    </ErrorBoundary>
+  )
+}

--- a/src/components/quiz/QuizListErrorBoundary/index.ts
+++ b/src/components/quiz/QuizListErrorBoundary/index.ts
@@ -1,0 +1,1 @@
+export { QuizListErrorBoundary } from './QuizListErrorBoundary'

--- a/src/components/quiz/index.ts
+++ b/src/components/quiz/index.ts
@@ -1,0 +1,4 @@
+export { QuizCard } from './QuizCard'
+export { QuizCardSkeleton } from './QuizCardSkeleton'
+export { QuizList } from './QuizList'
+export { QuizListErrorBoundary } from './QuizListErrorBoundary'

--- a/src/features/exams/deployments/handler.ts
+++ b/src/features/exams/deployments/handler.ts
@@ -1,0 +1,212 @@
+import { http, HttpResponse } from 'msw'
+import type { DeploymentsResponse } from './types'
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
+
+const PAGE_SIZE = 3
+
+const allItems: DeploymentsResponse['results'] = [
+  {
+    id: 1,
+    submission_id: 101,
+    exam: {
+      id: 10,
+      title: 'Python 기초 쪽지시험',
+      thumbnail_img_url: 'https://placehold.co/48x48',
+      subject: { id: 1, title: 'Python 입문', thumbnail_img_url: null },
+    },
+    question_count: 10,
+    total_score: 100,
+    exam_info: { status: 'done', score: 80, correct_answer_count: 8 },
+    is_done: true,
+    duration_time: 30,
+  },
+  {
+    id: 2,
+    submission_id: null,
+    exam: {
+      id: 11,
+      title: 'JavaScript 심화 쪽지시험',
+      thumbnail_img_url: 'https://placehold.co/48x48',
+      subject: { id: 2, title: 'JavaScript 심화', thumbnail_img_url: null },
+    },
+    question_count: 15,
+    total_score: 100,
+    exam_info: { status: 'pending', score: null, correct_answer_count: null },
+    is_done: false,
+    duration_time: 45,
+  },
+  {
+    id: 3,
+    submission_id: null,
+    exam: {
+      id: 12,
+      title: 'React 기초 쪽지시험',
+      thumbnail_img_url: 'https://placehold.co/48x48',
+      subject: { id: 3, title: 'React 기초', thumbnail_img_url: null },
+    },
+    question_count: 10,
+    total_score: 100,
+    exam_info: { status: 'pending', score: null, correct_answer_count: null },
+    is_done: false,
+    duration_time: 30,
+  },
+  {
+    id: 4,
+    submission_id: 202,
+    exam: {
+      id: 13,
+      title: 'TypeScript 기초 쪽지시험',
+      thumbnail_img_url: 'https://placehold.co/48x48',
+      subject: { id: 4, title: 'TypeScript', thumbnail_img_url: null },
+    },
+    question_count: 12,
+    total_score: 100,
+    exam_info: { status: 'done', score: 92, correct_answer_count: 11 },
+    is_done: true,
+    duration_time: 30,
+  },
+  {
+    id: 5,
+    submission_id: null,
+    exam: {
+      id: 14,
+      title: 'CSS 레이아웃 쪽지시험',
+      thumbnail_img_url: 'https://placehold.co/48x48',
+      subject: { id: 5, title: 'CSS', thumbnail_img_url: null },
+    },
+    question_count: 8,
+    total_score: 100,
+    exam_info: { status: 'pending', score: null, correct_answer_count: null },
+    is_done: false,
+    duration_time: 20,
+  },
+  {
+    id: 6,
+    submission_id: 303,
+    exam: {
+      id: 15,
+      title: 'HTML 기초 쪽지시험',
+      thumbnail_img_url: 'https://placehold.co/48x48',
+      subject: { id: 6, title: 'HTML', thumbnail_img_url: null },
+    },
+    question_count: 10,
+    total_score: 100,
+    exam_info: { status: 'done', score: 70, correct_answer_count: 7 },
+    is_done: true,
+    duration_time: 25,
+  },
+  {
+    id: 7,
+    submission_id: null,
+    exam: {
+      id: 16,
+      title: 'Git 기초 쪽지시험',
+      thumbnail_img_url: 'https://placehold.co/48x48',
+      subject: { id: 7, title: 'Git & GitHub', thumbnail_img_url: null },
+    },
+    question_count: 10,
+    total_score: 100,
+    exam_info: { status: 'pending', score: null, correct_answer_count: null },
+    is_done: false,
+    duration_time: 20,
+  },
+  {
+    id: 8,
+    submission_id: 404,
+    exam: {
+      id: 17,
+      title: 'SQL 기초 쪽지시험',
+      thumbnail_img_url: 'https://placehold.co/48x48',
+      subject: { id: 8, title: 'SQL', thumbnail_img_url: null },
+    },
+    question_count: 12,
+    total_score: 100,
+    exam_info: { status: 'done', score: 58, correct_answer_count: 7 },
+    is_done: true,
+    duration_time: 30,
+  },
+  {
+    id: 9,
+    submission_id: null,
+    exam: {
+      id: 18,
+      title: 'REST API 설계 쪽지시험',
+      thumbnail_img_url: 'https://placehold.co/48x48',
+      subject: { id: 9, title: 'REST API', thumbnail_img_url: null },
+    },
+    question_count: 10,
+    total_score: 100,
+    exam_info: { status: 'pending', score: null, correct_answer_count: null },
+    is_done: false,
+    duration_time: 25,
+  },
+  {
+    id: 10,
+    submission_id: 505,
+    exam: {
+      id: 19,
+      title: 'Node.js 기초 쪽지시험',
+      thumbnail_img_url: 'https://placehold.co/48x48',
+      subject: { id: 10, title: 'Node.js', thumbnail_img_url: null },
+    },
+    question_count: 15,
+    total_score: 100,
+    exam_info: { status: 'done', score: 100, correct_answer_count: 15 },
+    is_done: true,
+    duration_time: 40,
+  },
+  {
+    id: 11,
+    submission_id: null,
+    exam: {
+      id: 20,
+      title: 'Docker 기초 쪽지시험',
+      thumbnail_img_url: 'https://placehold.co/48x48',
+      subject: { id: 11, title: 'Docker', thumbnail_img_url: null },
+    },
+    question_count: 10,
+    total_score: 100,
+    exam_info: { status: 'pending', score: null, correct_answer_count: null },
+    is_done: false,
+    duration_time: 30,
+  },
+  {
+    id: 12,
+    submission_id: 606,
+    exam: {
+      id: 21,
+      title: 'Redux 심화 쪽지시험',
+      thumbnail_img_url: 'https://placehold.co/48x48',
+      subject: { id: 12, title: 'Redux', thumbnail_img_url: null },
+    },
+    question_count: 10,
+    total_score: 100,
+    exam_info: { status: 'done', score: 60, correct_answer_count: 6 },
+    is_done: true,
+    duration_time: 25,
+  },
+]
+
+// GET /api/v1/exams/deployments — 쪽지시험 목록 조회 API
+export const deploymentsHandlers = [
+  http.get(`${BASE_URL}/exams/deployments`, async ({ request }) => {
+    const url = new URL(request.url)
+
+    const status = url.searchParams.get('status') ?? 'all'
+    const page = Number(url.searchParams.get('page') ?? '1')
+
+    const filtered =
+      status === 'done'
+        ? allItems.filter((item) => item.exam_info.status === 'done')
+        : status === 'pending'
+          ? allItems.filter((item) => item.exam_info.status === 'pending')
+          : allItems
+
+    const start = (page - 1) * PAGE_SIZE
+    const results = filtered.slice(start, start + PAGE_SIZE)
+    const has_next = start + PAGE_SIZE < filtered.length
+
+    return HttpResponse.json<DeploymentsResponse>({ page, has_next, results })
+  }),
+]

--- a/src/features/exams/deployments/index.ts
+++ b/src/features/exams/deployments/index.ts
@@ -1,0 +1,10 @@
+export type {
+  DeploymentsParams,
+  DeploymentsResponse,
+  DeploymentListItem,
+  DeploymentExam,
+  DeploymentExamInfo,
+  DeploymentSubject,
+} from './types'
+export { deploymentsHandlers } from './handler'
+export { deploymentsQueries, useDeployments } from './queries'

--- a/src/features/exams/deployments/queries.ts
+++ b/src/features/exams/deployments/queries.ts
@@ -1,0 +1,30 @@
+import {
+  infiniteQueryOptions,
+  useSuspenseInfiniteQuery,
+} from '@tanstack/react-query'
+import api from '@/api/instance'
+import type { DeploymentsParams, DeploymentsResponse } from './types'
+
+type DeploymentsFilterParams = Omit<DeploymentsParams, 'page'>
+
+export const deploymentsQueries = {
+  all: () => ({ queryKey: ['exams', 'deployments'] as const }),
+  list: (params?: DeploymentsFilterParams) =>
+    infiniteQueryOptions({
+      queryKey: [...deploymentsQueries.all().queryKey, 'list', params],
+      queryFn: async ({ pageParam }) => {
+        const { data } = await api.get<DeploymentsResponse>(
+          'exams/deployments',
+          { params: { ...params, page: pageParam } }
+        )
+        return data
+      },
+      initialPageParam: 1,
+      getNextPageParam: (lastPage) =>
+        lastPage.has_next ? lastPage.page + 1 : undefined,
+    }),
+}
+
+export function useDeployments(params?: DeploymentsFilterParams) {
+  return useSuspenseInfiniteQuery(deploymentsQueries.list(params))
+}

--- a/src/features/exams/deployments/types.ts
+++ b/src/features/exams/deployments/types.ts
@@ -1,0 +1,42 @@
+/** GET /api/v1/exams/deployments 쿼리 파라미터 */
+export interface DeploymentsParams {
+  page?: number
+  status?: 'all' | 'done' | 'pending'
+}
+
+export interface DeploymentSubject {
+  id: number
+  title: string
+  thumbnail_img_url: string | null
+}
+
+export interface DeploymentExam {
+  id: number
+  title: string
+  thumbnail_img_url: string
+  subject: DeploymentSubject
+}
+
+export interface DeploymentExamInfo {
+  status: 'done' | 'pending'
+  score: number | null
+  correct_answer_count: number | null
+}
+
+export interface DeploymentListItem {
+  id: number
+  submission_id: number | null
+  exam: DeploymentExam
+  question_count: number
+  total_score: number
+  exam_info: DeploymentExamInfo
+  is_done: boolean
+  duration_time: number
+}
+
+/** GET /api/v1/exams/deployments 응답 */
+export interface DeploymentsResponse {
+  page: number
+  has_next: boolean
+  results: DeploymentListItem[]
+}

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from 'react'
+
+interface UseIntersectionObserverOptions {
+  onIntersect: () => void
+  enabled?: boolean
+}
+
+export function useIntersectionObserver({
+  onIntersect,
+  enabled = true,
+}: UseIntersectionObserverOptions) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!enabled || !ref.current) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          onIntersect()
+        }
+      },
+      { threshold: 0.1 }
+    )
+
+    observer.observe(ref.current)
+    return () => observer.disconnect()
+  }, [enabled, onIntersect])
+
+  return ref
+}

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,8 +1,10 @@
 import { http, HttpResponse } from 'msw'
+import { deploymentsHandlers } from '@/features/exams/deployments'
 
 export const handlers = [
   // 예시 핸들러 — 실제 API에 맞게 수정하세요
   http.get('/api/health', () => {
     return HttpResponse.json({ status: 'ok' })
   }),
+  ...deploymentsHandlers,
 ]

--- a/src/pages/quiz/QuizListPage.tsx
+++ b/src/pages/quiz/QuizListPage.tsx
@@ -35,7 +35,9 @@ export function QuizListPage() {
 
   return (
     <div className="flex flex-col gap-6">
-      <h1 className="text-text-heading text-2xl font-bold">쪽지시험</h1>
+      <h1 className="text-text-heading text-[32px] leading-[140%] font-bold tracking-[-0.03em]">
+        쪽지시험
+      </h1>
 
       <Tabs value={status} onChange={(v) => setStatus(v as TabStatus)}>
         <TabList aria-label="쪽지시험 필터">

--- a/src/pages/quiz/QuizListPage.tsx
+++ b/src/pages/quiz/QuizListPage.tsx
@@ -1,6 +1,61 @@
-/**
- * @figma 마이페이지_쪽지시험  https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-3499&m=dev
- */
+import { Suspense, useState } from 'react'
+import { Tabs, TabList, Tab, TabPanel } from '@/components'
+import {
+  QuizCardSkeleton,
+  QuizList,
+  QuizListErrorBoundary,
+} from '@/components/quiz'
+
+const QUIZ_STATUS = {
+  ALL: 'all',
+  DONE: 'done',
+  PENDING: 'pending',
+} as const
+
+type TabStatus = (typeof QUIZ_STATUS)[keyof typeof QUIZ_STATUS]
+
+const tabs: { label: string; value: TabStatus }[] = [
+  { label: '전체보기', value: QUIZ_STATUS.ALL },
+  { label: '응시완료', value: QUIZ_STATUS.DONE },
+  { label: '미응시', value: QUIZ_STATUS.PENDING },
+]
+
+function QuizListSkeleton() {
+  return (
+    <div className="flex flex-col gap-4">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <QuizCardSkeleton key={i} />
+      ))}
+    </div>
+  )
+}
+
 export function QuizListPage() {
-  return <div>쪽지시험 목록</div>
+  const [status, setStatus] = useState<TabStatus>('all')
+
+  return (
+    <div className="flex flex-col gap-6">
+      <h1 className="text-text-heading text-2xl font-bold">쪽지시험</h1>
+
+      <Tabs value={status} onChange={(v) => setStatus(v as TabStatus)}>
+        <TabList aria-label="쪽지시험 필터">
+          {tabs.map(({ label, value }) => (
+            <Tab key={value} value={value}>
+              {label}
+            </Tab>
+          ))}
+        </TabList>
+
+        {tabs.map(({ value }) => (
+          <TabPanel key={value} value={value} className="pt-6">
+            <QuizListErrorBoundary>
+              <Suspense fallback={<QuizListSkeleton />}>
+                <QuizList params={{ status: value }} />
+              </Suspense>
+            </QuizListErrorBoundary>
+          </TabPanel>
+        ))}
+      </Tabs>
+    </div>
+  )
 }

--- a/src/providers/RouterProvider.tsx
+++ b/src/providers/RouterProvider.tsx
@@ -1,5 +1,6 @@
 import { Routes, Route } from 'react-router'
 import { DefaultLayout, AuthLayout } from '@/components'
+import { MypageLayout } from '@/components/mypage'
 import { HomePage } from '@/pages/home'
 import { LoginPage } from '@/pages/auth'
 import { SignupSelectPage, SignupPage } from '@/pages/signup'
@@ -23,7 +24,7 @@ export function RouterProvider() {
       <Route element={<DefaultLayout />}>
         <Route index element={<HomePage />} />
 
-        <Route path="mypage">
+        <Route path="mypage" element={<MypageLayout />}>
           <Route index element={<MypagePage />} />
           <Route path="edit" element={<MypageEditPage />} />
           <Route path="change-password" element={<ChangePasswordPage />} />


### PR DESCRIPTION
## 관련 이슈

- closes #2

## 작업 내용

- 쪽지시험 목록 API 연동 모듈 및 MSW 핸들러 구현 (`features/exams/deployments`)
- `useIntersectionObserver` 훅 추가 (무한 스크롤)
- `QuizCard`, `QuizCardSkeleton`, `QuizList`, `QuizListErrorBoundary` 컴포넌트 구현
- `MypageLayout`, `SidebarTab` 컴포넌트 구현
- 쪽지시험 목록 페이지 및 라우팅 추가

## 변경 사항

- `SidebarTab`: `button + navigate()` → `NavLink` 전환 (접근성 개선)
- `QuizList`: React Compiler 환경에 맞게 `useCallback` 제거
- `QuizCard`: 피그마 디자인 스펙 반영 (타이포그래피), `score`/`correct_answer_count` null 안전 처리, `Link + Button` 중첩 → `Button + useNavigate` 전환
- `Button` (md): 피그마 스펙에 맞게 `font-semibold`, `leading-[140%]`, `tracking-[-0.03em]` 적용
- `QuizListPage`: 제목 폰트 크기 `text-2xl` → `text-[32px]` 수정

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다