### PR TITLE
Feat/10  loginpage

### DIFF
--- a/src/features/accounts/login/handler.ts
+++ b/src/features/accounts/login/handler.ts
@@ -1,0 +1,33 @@
+import { http, HttpResponse } from 'msw'
+
+export const loginHandlers = [
+  http.post('/api/v1/accounts/login', async ({ request }) => {
+    const body = (await request.json()) as { email: string; password: string }
+
+    if (body.email === 'withdrawn@test.com') {
+      return HttpResponse.json(
+        {
+          error_detail: {
+            detail: '탈퇴 신청한 계정입니다.',
+            expire_at: '2025-05-01',
+          },
+        },
+        { status: 403 }
+      )
+    }
+
+    if (body.email === 'test@test.com' && body.password === 'Test1234!@') {
+      return HttpResponse.json(
+        { access_token: 'mock_access_token' },
+        { status: 200 }
+      )
+    }
+
+    return HttpResponse.json(
+      {
+        error_detail: '이메일 또는 비밀번호가 올바르지 않습니다.',
+      },
+      { status: 400 }
+    )
+  }),
+]

--- a/src/features/accounts/login/index.ts
+++ b/src/features/accounts/login/index.ts
@@ -1,0 +1,10 @@
+import instance from '@/api/instance'
+import type { LoginRequest, LoginResponse } from './types'
+
+export const login = async (data: LoginRequest): Promise<LoginResponse> => {
+  const response = await instance.post<LoginResponse>(
+    '/api/v1/accounts/login',
+    data
+  )
+  return response.data
+}

--- a/src/features/accounts/login/queries.ts
+++ b/src/features/accounts/login/queries.ts
@@ -1,0 +1,14 @@
+import { useMutation } from '@tanstack/react-query'
+import { login } from './index'
+import type { LoginRequest, LoginResponse, LoginErrorResponse } from './types'
+import type { AxiosError } from 'axios'
+
+export const useLogin = () => {
+  return useMutation<
+    LoginResponse,
+    AxiosError<LoginErrorResponse>,
+    LoginRequest
+  >({
+    mutationFn: (data: LoginRequest) => login(data),
+  })
+}

--- a/src/features/accounts/login/types.ts
+++ b/src/features/accounts/login/types.ts
@@ -1,0 +1,12 @@
+export interface LoginRequest {
+  email: string
+  password: string
+}
+
+export interface LoginResponse {
+  access_token: string
+}
+
+export interface LoginErrorResponse {
+  error_detail: Record<string, string[]> | string
+}

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,10 +1,11 @@
 import { http, HttpResponse } from 'msw'
 import { deploymentsHandlers } from '@/features/exams/deployments'
+import { loginHandlers } from '@/features/accounts/login/handler'
 
 export const handlers = [
-  // 예시 핸들러 — 실제 API에 맞게 수정하세요
   http.get('/api/health', () => {
     return HttpResponse.json({ status: 'ok' })
   }),
   ...deploymentsHandlers,
+  ...loginHandlers,
 ]

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -72,11 +72,11 @@ export function LoginPage() {
   }
 
   return (
-    <main className="flex flex-1 flex-col items-center justify-center px-4 py-12">
+    <main className="flex flex-1 flex-col items-center px-4 pt-22">
       <div className="flex w-full max-w-sm flex-col items-center gap-6">
         <div className="flex w-full flex-col items-center gap-4">
-          <img src={logo} alt="OZ 오즈코딩스쿨" className="h-5 w-auto" />
-          <p className="text-text-muted text-sm">
+          <img src={logo} alt="OZ 오즈코딩스쿨" className="h-6 w-45" />
+          <p className="text-base text-gray-600">
             아직 회원이 아니신가요?{' '}
             <Link to="/signup" className="text-primary font-medium">
               회원가입 하기
@@ -84,7 +84,7 @@ export function LoginPage() {
           </p>
         </div>
 
-        <div className="mt-4 flex w-full flex-col gap-3">
+        <div className="mt-12 flex w-full flex-col gap-3">
           <SocialLoginButton provider="kakao" />
           <SocialLoginButton provider="naver" />
         </div>
@@ -113,8 +113,7 @@ export function LoginPage() {
             isError={Boolean(passwordError)}
             errorMessage={passwordError}
           />
-
-          <div className="text-text-muted flex gap-2 text-sm">
+          <div className="flex gap-2 text-sm text-gray-600">
             <button type="button">아이디 찾기</button>
             <span>|</span>
             <button type="button">비밀번호 찾기</button>

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -1,6 +1,143 @@
-/**
- * @figma 로그인  https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-1100&m=dev
- */
+import { useState } from 'react'
+import { useNavigate, Link } from 'react-router'
+import { Input } from '@/components/common/Input'
+import { PasswordInput } from '@/components/common/PasswordInput'
+import { Button } from '@/components/common/Button'
+import { SocialLoginButton } from '@/components/common/SocialLoginButton'
+import { AlertModal } from '@/components/common/Modal/AlertModal'
+import { useLogin } from '@/features/accounts/login/queries'
+import type { AxiosError } from 'axios'
+import type { LoginErrorResponse } from '@/features/accounts/login/types'
+import logo from '@/assets/logo.png'
+
 export function LoginPage() {
-  return <div>로그인</div>
+  const navigate = useNavigate()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [emailError, setEmailError] = useState('')
+  const [passwordError, setPasswordError] = useState('')
+  const [alertMessage, setAlertMessage] = useState('')
+  const [isAlertOpen, setIsAlertOpen] = useState(false)
+
+  const { mutate: login, isPending } = useLogin()
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+
+    if (!email) {
+      setEmailError('이 필드는 필수 항목입니다.')
+      return
+    }
+    if (!password) {
+      setPasswordError('이 필드는 필수 항목입니다.')
+      return
+    }
+
+    login(
+      { email, password },
+      {
+        onSuccess: (data) => {
+          localStorage.setItem('access_token', data.access_token)
+          navigate('/')
+        },
+        onError: (error: AxiosError<LoginErrorResponse>) => {
+          const errorDetail = error.response?.data?.error_detail
+
+          if (!errorDetail) return
+
+          if (typeof errorDetail === 'string') {
+            setAlertMessage(errorDetail)
+            setIsAlertOpen(true)
+          } else {
+            if (errorDetail.detail) {
+              const detail = errorDetail as unknown as {
+                detail: string
+                expire_at: string
+              }
+              setAlertMessage(
+                `${detail.detail}\n복구 가능 날짜: ${detail.expire_at}`
+              )
+              setIsAlertOpen(true)
+            }
+            if (errorDetail.email) {
+              setEmailError(errorDetail.email[0])
+            }
+            if (errorDetail.password) {
+              setPasswordError(errorDetail.password[0])
+            }
+          }
+        },
+      }
+    )
+  }
+
+  return (
+    <main className="flex flex-1 flex-col items-center justify-center px-4 py-12">
+      <div className="flex w-full max-w-sm flex-col items-center gap-6">
+        <div className="flex w-full flex-col items-center gap-4">
+          <img src={logo} alt="OZ 오즈코딩스쿨" className="h-5 w-auto" />
+          <p className="text-text-muted text-sm">
+            아직 회원이 아니신가요?{' '}
+            <Link to="/signup" className="text-primary font-medium">
+              회원가입 하기
+            </Link>
+          </p>
+        </div>
+
+        <div className="mt-4 flex w-full flex-col gap-3">
+          <SocialLoginButton provider="kakao" />
+          <SocialLoginButton provider="naver" />
+        </div>
+
+        <form onSubmit={handleSubmit} className="flex w-full flex-col gap-3">
+          <Input
+            label="아이디"
+            type="email"
+            placeholder="example@gmail.com"
+            value={email}
+            onChange={(e) => {
+              setEmail(e.target.value)
+              setEmailError('')
+            }}
+            isError={Boolean(emailError)}
+            errorMessage={emailError}
+          />
+          <PasswordInput
+            label="비밀번호"
+            placeholder="6~15자리 영문 대소문자, 숫자, 특수문자 포함"
+            value={password}
+            onChange={(e) => {
+              setPassword(e.target.value)
+              setPasswordError('')
+            }}
+            isError={Boolean(passwordError)}
+            errorMessage={passwordError}
+          />
+
+          <div className="text-text-muted flex gap-2 text-sm">
+            <button type="button">아이디 찾기</button>
+            <span>|</span>
+            <button type="button">비밀번호 찾기</button>
+          </div>
+
+          <Button
+            type="submit"
+            fullWidth
+            loading={isPending}
+            disabled={!email || !password}
+          >
+            일반회원 로그인
+          </Button>
+        </form>
+      </div>
+
+      <AlertModal
+        isOpen={isAlertOpen}
+        onClose={() => setIsAlertOpen(false)}
+        message={alertMessage}
+      />
+    </main>
+  )
 }
+
+export default LoginPage

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -59,9 +59,6 @@ export function LoginPage() {
               )
               setIsAlertOpen(true)
             }
-            if (errorDetail.email) {
-              setEmailError(errorDetail.email[0])
-            }
             if (errorDetail.password) {
               setPasswordError(errorDetail.password[0])
             }

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -37,7 +37,7 @@ export function LoginPage() {
       { email, password },
       {
         onSuccess: (data) => {
-          localStorage.setItem('access_token', data.access_token)
+          localStorage.setItem('accesstoken', data.access_token)
           navigate('/')
         },
         onError: (error: AxiosError<LoginErrorResponse>) => {


### PR DESCRIPTION
## 관련 이슈

- closes #10 

## 작업 내용

이메일/비밀번호 로그인 API 연동
로그인 성공 시 accessToken localStorage 저장 후 메인 페이지 이동
마스킹 된 비밀번호 보기 기능
400 에러: 이메일/비밀번호 불일치 시 AlertModal 표시
403 에러: 탈퇴 신청 계정 로그인 시 복구 가능 날짜 포함 AlertModal 표시
MSW 핸들러 등록 (성공 / 탈퇴 계정 / 로그인 실패 케이스)


## 테스트 방법
케이스             이메일                     비밀번호
성공            test@test.com           Test1234!@
탈퇴 계정withdrawn@test.com    Test1234!@
없는 계정         아무거나                  아무거나

## 스크린샷
성공
<img width="1919" height="682" alt="image" src="https://github.com/user-attachments/assets/8ebf283f-fba2-49a7-83aa-da54907cfb3b" />
200과 함께 렌딩페이지로 이동
<img width="552" height="680" alt="image" src="https://github.com/user-attachments/assets/21ad7813-0a24-4ecb-8875-7c812a214824" />
access토큰 localstorage에 발급

탈퇴계정
<img width="1919" height="688" alt="image" src="https://github.com/user-attachments/assets/af5a425a-7ddc-4b67-aae7-206dbf4a9473" />
403과 함께 에러모달

없는 계정
<img width="1919" height="684" alt="image" src="https://github.com/user-attachments/assets/2e291dfe-956a-44ef-a289-8f0367253656" />
400과 함꼐 에러모달




## 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다
- [ ] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [ ] 컨벤션에 맞게 작성했습니다
