### PR TITLE
fix: observer 매 렌더마다 재생성되는 버그 수정 (#23)

### DIFF
--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useLayoutEffect, useRef } from 'react'
 
 interface UseIntersectionObserverOptions {
   onIntersect: () => void
@@ -10,6 +10,10 @@ export function useIntersectionObserver({
   enabled = true,
 }: UseIntersectionObserverOptions) {
   const ref = useRef<HTMLDivElement>(null)
+  const onIntersectRef = useRef(onIntersect)
+  useLayoutEffect(() => {
+    onIntersectRef.current = onIntersect
+  })
 
   useEffect(() => {
     if (!enabled || !ref.current) return
@@ -17,7 +21,7 @@ export function useIntersectionObserver({
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries[0].isIntersecting) {
-          onIntersect()
+          onIntersectRef.current()
         }
       },
       { threshold: 0.1 }
@@ -25,7 +29,7 @@ export function useIntersectionObserver({
 
     observer.observe(ref.current)
     return () => observer.disconnect()
-  }, [enabled, onIntersect])
+  }, [enabled])
 
   return ref
 }


### PR DESCRIPTION
## 관련 이슈

- closes #23

## 작업 내용

- `onIntersect`를 `useLayoutEffect`로 ref에 동기화하고 dependency array에서 제거

## 변경 사항

- `useEffect` dependency array에 인라인 함수(`onIntersect`)가 포함되어 매 렌더마다 `IntersectionObserver`가 disconnect/reconnect되는 버그 수정
- `onIntersectRef`로 최신 콜백을 유지하여 observer는 `enabled` 변경 시에만 재생성되도록 개선

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다