### PR TITLE
refactor: ExamThumbnail 컴포넌트 분리로 썸네일 블록 중복 제거 (#24)

### DIFF
--- a/src/components/quiz/ExamThumbnail/ExamThumbnail.tsx
+++ b/src/components/quiz/ExamThumbnail/ExamThumbnail.tsx
@@ -1,0 +1,19 @@
+interface ExamThumbnailProps {
+  src: string
+  alt: string
+}
+
+export function ExamThumbnail({ src, alt }: ExamThumbnailProps) {
+  return (
+    <div className="bg-primary-100 flex h-12 w-12 shrink-0 items-center justify-center p-2.5">
+      <img
+        src={src}
+        alt={alt}
+        width={28}
+        height={28}
+        loading="lazy"
+        className="h-full w-full object-contain"
+      />
+    </div>
+  )
+}

--- a/src/components/quiz/ExamThumbnail/index.ts
+++ b/src/components/quiz/ExamThumbnail/index.ts
@@ -1,0 +1,1 @@
+export { ExamThumbnail } from './ExamThumbnail'

--- a/src/components/quiz/QuizCard/QuizCard.tsx
+++ b/src/components/quiz/QuizCard/QuizCard.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router'
 import { Button } from '@/components/common/Button'
 import { ROUTES } from '@/constants/routes'
+import { ExamThumbnail } from '@/components/quiz/ExamThumbnail'
 import { QuizCodeModal } from '@/components/quiz/QuizCodeModal'
 import type { DeploymentListItem } from '@/features/exams/deployments'
 
@@ -82,16 +83,7 @@ export function QuizCard({ item }: QuizCardProps) {
     <div className="border-disable flex h-[104px] w-full items-center justify-between rounded-lg border bg-gray-100 px-8 py-7">
       {/* 좌측: 아이콘 + 시험 정보 */}
       <div className="flex items-center gap-4">
-        <div className="bg-primary-100 flex h-12 w-12 shrink-0 items-center justify-center p-2.5">
-          <img
-            src={exam.thumbnail_img_url}
-            alt={exam.title}
-            width={28}
-            height={28}
-            loading="lazy"
-            className="h-full w-full object-contain"
-          />
-        </div>
+        <ExamThumbnail src={exam.thumbnail_img_url} alt={exam.title} />
         <div className="flex flex-col justify-center gap-1">
           <div className="flex items-center gap-3">
             <span className="text-lg leading-[140%] font-semibold tracking-[-0.03em] text-black">

--- a/src/components/quiz/QuizCodeModal/QuizCodeModal.tsx
+++ b/src/components/quiz/QuizCodeModal/QuizCodeModal.tsx
@@ -4,6 +4,7 @@ import axios from 'axios'
 import { Modal } from '@/components/common/Modal'
 import { Input } from '@/components/common/Input'
 import { Button } from '@/components/common/Button'
+import { ExamThumbnail } from '@/components/quiz/ExamThumbnail'
 import { ROUTES } from '@/constants/routes'
 import { HTTP_STATUS } from '@/constants/httpStatus'
 import { useCheckCode } from '@/features/exams/deployment-check-code'
@@ -94,16 +95,7 @@ export function QuizCodeModal({
     <Modal isOpen={isOpen} onClose={handleClose} maxWidth="max-w-sm">
       {/* 시험 정보 */}
       <div className="mb-8 flex flex-col items-center gap-3">
-        <div className="bg-primary-100 flex h-12 w-12 shrink-0 items-center justify-center p-2.5">
-          <img
-            src={thumbnailUrl}
-            alt={examTitle}
-            width={28}
-            height={28}
-            loading="lazy"
-            className="h-full w-full object-contain"
-          />
-        </div>
+        <ExamThumbnail src={thumbnailUrl} alt={examTitle} />
         <div className="flex flex-col items-center gap-1">
           <span className="text-text-heading text-lg leading-[140%] font-semibold tracking-[-0.03em]">
             {examTitle}

--- a/src/components/quiz/index.ts
+++ b/src/components/quiz/index.ts
@@ -1,3 +1,4 @@
+export { ExamThumbnail } from './ExamThumbnail'
 export { QuizCard } from './QuizCard'
 export { QuizCardSkeleton } from './QuizCardSkeleton'
 export { QuizList } from './QuizList'


### PR DESCRIPTION
## 관련 이슈

- closes #24

## 작업 내용

- `QuizCard`, `QuizCodeModal`에 중복된 썸네일 아이콘 마크업을 `ExamThumbnail` 컴포넌트로 추출

## 변경 사항

- `src/components/quiz/ExamThumbnail` 컴포넌트 신규 생성 (`src`, `alt` props)
- `QuizCard`, `QuizCodeModal`에서 중복 마크업 제거 후 `ExamThumbnail`로 교체

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다