### PR TITLE
feat: 마이페이지 수정하기 구현(#16)

### DIFF
--- a/docs/guide/API_GUIDE.md
+++ b/docs/guide/API_GUIDE.md
@@ -26,4 +26,100 @@ tag: 'str',
 thumbnail_img_url: 'str',
 },
 },
+'PUT api/v1/accounts/me/profile-image/presigned-url': {  
+request: {  
+file_name: {  
+type: 'str',  
+required: 'true'  
+}  
+}  
+response: {
+presigned_url: 'str',  
+img_url: 'str',  
+key: 'str'  
+}
+}  
+'api/v1/accounts/me/profile-image': {
+request: {
+profile_img_url: 'str'
+}
+response: {
+detail: 'str'
+}
+}
+'PATCH api/v1/accounts/change-phone': {
+request: {
+phone_verify_token: {
+type: 'str',
+required: 'true',
+}
+}
+response: {
+detail: 'str',
+phone_number: 'str'
+}
+}
+'PATCH api/v1/accounts/me': {
+request : {
+nickname: {
+type: 'str',
+required: 'false',
+},
+name: {
+type: 'str',
+required: 'false',
+},
+birthday: {
+type: 'date',
+format: 'YYYY-MM-DD,
+required: 'false',
+},
+gender: {
+type: 'enum("M", "F")',
+required: 'false',
+}
+}
+response:  
+{
+id: 'int',
+email: 'str',
+nickname: 'str',
+name: 'str',
+birthday: 'str',
+gender: 'enum("M","F")'
+phone_number: 'str',
+updated_at: 'datetime'
+}
+}
+'POST api/v1/accounts/verification/send-sms': {
+request: {phone_number: {
+type: 'str',
+format:' r"^\+\d{11,15}$"',
+required: 'true',
+},
+purpose: {
+type: 'str',
+choices: '["signup", "find_email", "phone_change"]',
+required: 'true',
+}
+}
+}
+'POST api/v1/accounts/verification/verify-sms': {
+request: {
+phone_number: {
+type: 'str',
+format: 'r"\+\d{11}"',
+required: 'true',
+},
+code: {
+type: 'str',
+format: 'r"^\d{6}$"',
+required: 'true',
+}
+}
+response:200: {
+detail: 'str'
+sms_token: 'str'
+}
+}
 }

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -76,7 +76,9 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
                 : 'border-border-base focus:border-primary',
             disabled
               ? 'bg-bg-muted text-text-muted cursor-not-allowed opacity-60'
-              : '',
+              : props.readOnly
+                ? 'bg-bg-muted text-text-muted focus:border-border-base cursor-default'
+                : '',
             className,
           ]
             .filter(Boolean)

--- a/src/features/accounts/check-nickname/handler.ts
+++ b/src/features/accounts/check-nickname/handler.ts
@@ -1,0 +1,21 @@
+import { http, HttpResponse } from 'msw'
+import type { CheckNicknameResponse } from './types'
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
+
+export const checkNicknameHandlers = [
+  http.post(`${BASE_URL}/accounts/check-nickname`, async ({ request }) => {
+    const { nickname } = (await request.json()) as { nickname: string }
+
+    if (nickname === '중복닉네임') {
+      return HttpResponse.json(
+        { detail: '이미 사용 중인 닉네임입니다.' },
+        { status: 400 }
+      )
+    }
+
+    return HttpResponse.json<CheckNicknameResponse>({
+      detail: '사용 가능한 닉네임입니다.',
+    })
+  }),
+]

--- a/src/features/accounts/check-nickname/index.ts
+++ b/src/features/accounts/check-nickname/index.ts
@@ -1,0 +1,3 @@
+export * from './types'
+export * from './queries'
+export * from './handler'

--- a/src/features/accounts/check-nickname/queries.ts
+++ b/src/features/accounts/check-nickname/queries.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query'
+import api from '@/api/instance'
+import type { CheckNicknameRequest, CheckNicknameResponse } from './types'
+
+export function useCheckNickname() {
+  return useMutation({
+    mutationFn: async (body: CheckNicknameRequest) => {
+      const { data } = await api.post<CheckNicknameResponse>(
+        'accounts/check-nickname',
+        body
+      )
+      return data
+    },
+  })
+}

--- a/src/features/accounts/check-nickname/types.ts
+++ b/src/features/accounts/check-nickname/types.ts
@@ -1,0 +1,7 @@
+export interface CheckNicknameRequest {
+  nickname: string
+}
+
+export interface CheckNicknameResponse {
+  detail: string
+}

--- a/src/features/accounts/me-profile-image/handler.ts
+++ b/src/features/accounts/me-profile-image/handler.ts
@@ -1,0 +1,22 @@
+import { http, HttpResponse } from 'msw'
+import type { PresignedUrlResponse, ProfileImageUpdateResponse } from './types'
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
+
+export const meProfileImageHandlers = [
+  http.put(`${BASE_URL}/accounts/me/profile-image/presigned-url`, () => {
+    return HttpResponse.json<PresignedUrlResponse>({
+      presigned_url: `${BASE_URL}/mock/s3-upload`,
+      img_url: 'https://example.com/profile/mock-image.jpg',
+      key: 'profile/mock-image.jpg',
+    })
+  }),
+  http.put(`${BASE_URL}/mock/s3-upload`, () => {
+    return new HttpResponse(null, { status: 200 })
+  }),
+  http.patch(`${BASE_URL}/accounts/me/profile-image`, () => {
+    return HttpResponse.json<ProfileImageUpdateResponse>({
+      detail: '프로필 이미지가 변경되었습니다.',
+    })
+  }),
+]

--- a/src/features/accounts/me-profile-image/index.ts
+++ b/src/features/accounts/me-profile-image/index.ts
@@ -1,0 +1,3 @@
+export * from './types'
+export * from './queries'
+export * from './handler'

--- a/src/features/accounts/me-profile-image/queries.ts
+++ b/src/features/accounts/me-profile-image/queries.ts
@@ -1,0 +1,37 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import api from '@/api/instance'
+import { meQueries } from '@/features/accounts/me'
+import type {
+  PresignedUrlRequest,
+  PresignedUrlResponse,
+  ProfileImageUpdateRequest,
+  ProfileImageUpdateResponse,
+} from './types'
+
+export function useGetPresignedUrl() {
+  return useMutation({
+    mutationFn: async (body: PresignedUrlRequest) => {
+      const { data } = await api.put<PresignedUrlResponse>(
+        'accounts/me/profile-image/presigned-url',
+        body
+      )
+      return data
+    },
+  })
+}
+
+export function useUpdateProfileImage() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (body: ProfileImageUpdateRequest) => {
+      const { data } = await api.patch<ProfileImageUpdateResponse>(
+        'accounts/me/profile-image',
+        body
+      )
+      return data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(meQueries.all())
+    },
+  })
+}

--- a/src/features/accounts/me-profile-image/types.ts
+++ b/src/features/accounts/me-profile-image/types.ts
@@ -1,0 +1,17 @@
+export interface PresignedUrlRequest {
+  file_name: string
+}
+
+export interface PresignedUrlResponse {
+  presigned_url: string
+  img_url: string
+  key: string
+}
+
+export interface ProfileImageUpdateRequest {
+  profile_img_url: string
+}
+
+export interface ProfileImageUpdateResponse {
+  detail: string
+}

--- a/src/features/accounts/me/handler.ts
+++ b/src/features/accounts/me/handler.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from 'msw'
-import type { MeResponse } from './types'
+import type { MeResponse, MeUpdateResponse } from './types'
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
 
@@ -16,6 +16,19 @@ export const meHandlers = [
       profile_img_url: null,
       cohort_id: 1,
       created_at: '2024-01-15T09:00:00Z',
+    })
+  }),
+  http.patch(`${BASE_URL}/accounts/me`, async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown>
+    return HttpResponse.json<MeUpdateResponse>({
+      id: 1,
+      email: 'ozschool1234@gmail.com',
+      nickname: (body.nickname as string) ?? '오즈오즈',
+      name: (body.name as string) ?? '김오즈',
+      birthday: (body.birthday as string) ?? '2000-12-25',
+      gender: (body.gender as 'M' | 'F') ?? 'M',
+      phone_number: '01012341234',
+      updated_at: new Date().toISOString(),
     })
   }),
 ]

--- a/src/features/accounts/me/queries.ts
+++ b/src/features/accounts/me/queries.ts
@@ -1,6 +1,11 @@
-import { queryOptions, useSuspenseQuery } from '@tanstack/react-query'
+import {
+  queryOptions,
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from '@tanstack/react-query'
 import api from '@/api/instance'
-import type { MeResponse } from './types'
+import type { MeResponse, MeUpdateRequest, MeUpdateResponse } from './types'
 
 export const meQueries = {
   all: () => ({ queryKey: ['accounts', 'me'] as const }),
@@ -16,4 +21,17 @@ export const meQueries = {
 
 export function useMe() {
   return useSuspenseQuery(meQueries.detail())
+}
+
+export function useUpdateMe() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (body: MeUpdateRequest) => {
+      const { data } = await api.patch<MeUpdateResponse>('accounts/me', body)
+      return data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(meQueries.all())
+    },
+  })
 }

--- a/src/features/accounts/me/types.ts
+++ b/src/features/accounts/me/types.ts
@@ -11,3 +11,21 @@ export interface MeResponse {
   cohort_id: number | null
   created_at: string
 }
+
+export interface MeUpdateRequest {
+  nickname?: string
+  name?: string
+  birthday?: string
+  gender?: 'M' | 'F'
+}
+
+export interface MeUpdateResponse {
+  id: number
+  email: string
+  nickname: string
+  name: string
+  birthday: string
+  gender: 'M' | 'F'
+  phone_number: string
+  updated_at: string
+}

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -4,6 +4,8 @@ import { loginHandlers } from '@/features/accounts/login/handler'
 import { meHandlers } from '@/features/accounts/me'
 import { meEnrolledCoursesHandlers } from '@/features/accounts/me-enrolled-courses'
 import { checkCodeHandlers } from '@/features/exams/deployment-check-code'
+import { checkNicknameHandlers } from '@/features/accounts/check-nickname'
+import { meProfileImageHandlers } from '@/features/accounts/me-profile-image'
 
 export const handlers = [
   http.get('/api/health', () => {
@@ -14,4 +16,6 @@ export const handlers = [
   ...deploymentsHandlers,
   ...loginHandlers,
   ...checkCodeHandlers,
+  ...checkNicknameHandlers,
+  ...meProfileImageHandlers,
 ]

--- a/src/pages/mypage/MypageEditPage.tsx
+++ b/src/pages/mypage/MypageEditPage.tsx
@@ -1,6 +1,306 @@
 /**
  * @figma 마이페이지_수정하기  https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-5240&m=dev
  */
+import { Suspense, useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router'
+import { Card, Button, Avatar, Input, Spinner } from '@/components'
+import { MypageErrorBoundary } from '@/components/mypage'
+import { ROUTES } from '@/constants/routes'
+import { useMe, useUpdateMe } from '@/features/accounts/me'
+import { useCheckNickname } from '@/features/accounts/check-nickname'
+import {
+  useGetPresignedUrl,
+  useUpdateProfileImage,
+} from '@/features/accounts/me-profile-image'
+import { formatPhone } from '@/utils/formatPhone'
+
+function CameraIcon() {
+  return (
+    <svg
+      width="40"
+      height="40"
+      viewBox="0 0 40 40"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx="20" cy="20" r="20" fill="#6C5CE7" />
+      <path
+        d="M16.5 13L15 15H12C11.17 15 10.5 15.67 10.5 16.5V26.5C10.5 27.33 11.17 28 12 28H28C28.83 28 29.5 27.33 29.5 26.5V16.5C29.5 15.67 28.83 15 28 15H25L23.5 13H16.5Z"
+        stroke="white"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle
+        cx="20"
+        cy="21.5"
+        r="3.5"
+        stroke="white"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+function MypageEditContent() {
+  const navigate = useNavigate()
+  const { data: me } = useMe()
+  const updateMe = useUpdateMe()
+  const checkNickname = useCheckNickname()
+  const getPresignedUrl = useGetPresignedUrl()
+  const updateProfileImage = useUpdateProfileImage()
+
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  // Profile image state
+  const [imageFile, setImageFile] = useState<File | null>(null)
+  const [imagePreview, setImagePreview] = useState<string | null>(null)
+
+  // Form state
+  const [nickname, setNickname] = useState(me.nickname)
+  const gender = me.gender
+  const [nicknameStatus, setNicknameStatus] = useState<
+    'idle' | 'valid' | 'invalid'
+  >('idle')
+
+  // Saving state
+  const [isSaving, setIsSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  // Critical 1: Object URL 메모리 누수 방지
+  useEffect(() => {
+    return () => {
+      if (imagePreview) URL.revokeObjectURL(imagePreview)
+    }
+  }, [imagePreview])
+
+  // Critical 2: check-nickname API 연동
+  function handleNicknameCheck() {
+    checkNickname.mutate(
+      { nickname },
+      {
+        onSuccess: () => setNicknameStatus('valid'),
+        onError: () => setNicknameStatus('invalid'),
+      }
+    )
+  }
+
+  function handleImageSelect() {
+    fileInputRef.current?.click()
+  }
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    // Critical 1: 이전 Object URL 해제
+    if (imagePreview) URL.revokeObjectURL(imagePreview)
+    setImageFile(file)
+    setImagePreview(URL.createObjectURL(file))
+  }
+
+  async function handleSave() {
+    setSaveError(null)
+    setIsSaving(true)
+    try {
+      // 1. Upload profile image if selected
+      if (imageFile) {
+        const presigned = await getPresignedUrl.mutateAsync({
+          file_name: imageFile.name,
+        })
+        await fetch(presigned.presigned_url, {
+          method: 'PUT',
+          body: imageFile,
+        })
+        await updateProfileImage.mutateAsync({
+          profile_img_url: presigned.img_url,
+        })
+      }
+
+      // 2. Update user info
+      await updateMe.mutateAsync({ nickname })
+
+      // 3. Navigate back
+      navigate(ROUTES.MYPAGE.HOME)
+    } catch {
+      // Critical 3: 에러 피드백
+      setSaveError('저장에 실패했습니다. 다시 시도해주세요.')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h1 className="text-text-heading self-start text-[32px] leading-[140%] font-bold tracking-[-0.03em]">
+          내 정보
+        </h1>
+        <Button
+          variant="primary"
+          size="lg"
+          onClick={handleSave}
+          loading={isSaving}
+          className="px-9 py-5"
+        >
+          저장하기
+        </Button>
+      </div>
+
+      {saveError && <p className="text-error text-sm">{saveError}</p>}
+
+      {/* Card */}
+      <Card padding="none" elevation="sm" className="px-10 py-[52px]">
+        {/* Profile Edit Section */}
+        <section className="mb-[52px] border-b border-gray-200 pb-[52px]">
+          <h2 className="text-primary-600 mb-5 border-b border-gray-200 pb-5 text-xl leading-[140%] font-semibold tracking-[-0.03em]">
+            프로필 수정
+          </h2>
+
+          {/* Avatar with camera overlay */}
+          <div className="mb-[44px] flex flex-col items-center">
+            <div className="relative">
+              <Avatar
+                src={imagePreview ?? me.profile_img_url}
+                alt={me.nickname}
+                className="h-[184px] w-[184px] text-6xl"
+              />
+              <button
+                type="button"
+                onClick={handleImageSelect}
+                className="absolute right-1 bottom-1 cursor-pointer rounded-full"
+                aria-label="프로필 이미지 변경"
+              >
+                <CameraIcon />
+              </button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                onChange={handleFileChange}
+                className="hidden"
+              />
+            </div>
+          </div>
+
+          {/* Nickname */}
+          <div className="mb-5">
+            <div className="flex items-end gap-2">
+              <div className="flex-1">
+                <Input
+                  label="닉네임"
+                  value={nickname}
+                  onChange={(e) => {
+                    setNickname(e.target.value)
+                    setNicknameStatus('idle')
+                  }}
+                  placeholder="닉네임을 입력하세요"
+                  helperText={
+                    nicknameStatus === 'idle'
+                      ? '*한글 8자, 영문 및 숫자 16자까지 혼용할 수 있어요.'
+                      : undefined
+                  }
+                  successMessage={
+                    nicknameStatus === 'valid'
+                      ? '사용 가능한 닉네임입니다.'
+                      : undefined
+                  }
+                  errorMessage={
+                    nicknameStatus === 'invalid'
+                      ? '올바른 닉네임 형식이 아닙니다.'
+                      : undefined
+                  }
+                />
+              </div>
+              <Button
+                variant="secondary"
+                size="md"
+                onClick={handleNicknameCheck}
+                loading={checkNickname.isPending}
+                disabled={!nickname}
+                className="mb-[22px] shrink-0"
+              >
+                중복확인
+              </Button>
+            </div>
+          </div>
+
+          {/* Email */}
+          <Input label="이메일" value={me.email} readOnly />
+        </section>
+
+        {/* Personal Info Edit Section */}
+        <section>
+          <h2 className="text-primary-600 mb-5 border-b border-gray-200 pb-5 text-xl leading-[140%] font-semibold tracking-[-0.03em]">
+            개인 정보 수정
+          </h2>
+
+          <div className="space-y-5">
+            {/* Name */}
+            <Input label="이름" value={me.name} readOnly />
+
+            {/* Phone */}
+            <div className="flex items-end gap-2">
+              <div className="flex-1">
+                <Input
+                  label="휴대전화"
+                  value={formatPhone(me.phone_number)}
+                  readOnly
+                />
+              </div>
+              <Button variant="primary" size="md" className="shrink-0">
+                변경하기
+              </Button>
+            </div>
+
+            {/* Gender (read-only) */}
+            <div>
+              <label className="text-text-heading mb-1.5 block text-sm font-medium">
+                성별
+              </label>
+              <div className="flex gap-2">
+                {(['M', 'F'] as const).map((g) => (
+                  <div
+                    key={g}
+                    className={`flex h-[42px] w-20 cursor-default items-center justify-center rounded-full text-base font-semibold select-none ${
+                      gender === g
+                        ? 'bg-primary-100 text-primary-600'
+                        : 'bg-bg-muted text-text-muted'
+                    }`}
+                  >
+                    {g === 'M' ? '남' : '여'}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Birthday */}
+            <Input
+              label="생년월일"
+              value={me.birthday?.replace(/-/g, '.') ?? ''}
+              readOnly
+            />
+          </div>
+        </section>
+      </Card>
+    </div>
+  )
+}
+
 export function MypageEditPage() {
-  return <div>마이페이지 - 수정</div>
+  return (
+    <MypageErrorBoundary>
+      <Suspense
+        fallback={
+          <div className="flex items-center justify-center py-20">
+            <Spinner size="lg" />
+          </div>
+        }
+      >
+        <MypageEditContent />
+      </Suspense>
+    </MypageErrorBoundary>
+  )
 }

--- a/src/pages/mypage/MypageEditPage.tsx
+++ b/src/pages/mypage/MypageEditPage.tsx
@@ -59,7 +59,7 @@ function MypageEditContent() {
   const [imagePreview, setImagePreview] = useState<string | null>(null)
 
   // Form state
-  const [nickname, setNickname] = useState(me.nickname)
+  const [nickname, setNickname] = useState(me.nickname ?? '')
   const gender = me.gender
   const [nicknameStatus, setNicknameStatus] = useState<
     'idle' | 'valid' | 'invalid'
@@ -109,10 +109,13 @@ function MypageEditContent() {
         const presigned = await getPresignedUrl.mutateAsync({
           file_name: imageFile.name,
         })
-        await fetch(presigned.presigned_url, {
+        const uploadRes = await fetch(presigned.presigned_url, {
           method: 'PUT',
           body: imageFile,
         })
+        if (!uploadRes.ok) {
+          throw new Error(`이미지 업로드 실패: ${uploadRes.status}`)
+        }
         await updateProfileImage.mutateAsync({
           profile_img_url: presigned.img_url,
         })


### PR DESCRIPTION
## 관련 이슈

- closes #16 

## 작업 내용

  - MypageEditPage 전체 UI 구현 (프로필 수정 + 개인정보 수정)
  - 프로필 이미지 업로드 (presigned URL → S3)
  - 저장하기 (PATCH /accounts/me)
  - 휴대전화 변경 디자인 유지 (API는 이슈 등록 후 연동 예정)
  - Critical 이슈 3개 수정 (메모리 누수, API 연동, 에러 피드백)

## 미완료 사항

- 백엔드 측에서 닉네임 중복확인 (POST /accounts/check-nickname) API 관련 누락으로 인해 추후에 fix 예정 

## 스크린샷 (선택)

## 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다
- [ ] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [ ] 컨벤션에 맞게 작성했습니다
