### PR TITLE
feat: 쪽지시험 응시 페이지 기본 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.claude/settings.json
 .claude/settings.local.json
 
 # Playwright

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "test:visual:update-baseline": "node --experimental-strip-types e2e/scripts/update-figma-baselines.ts"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/react-query": "^5.95.2",
     "axios": "^1.13.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.3(@types/node@24.12.0)(jiti@2.6.1)(yaml@2.8.3))
@@ -186,6 +195,28 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@emnapi/core@1.9.1':
     resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
@@ -2223,6 +2254,31 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
   '@emnapi/core@1.9.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.0
@@ -4021,8 +4077,7 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   type-check@0.4.0:
     dependencies:

--- a/src/assets/cheating/exit.svg
+++ b/src/assets/cheating/exit.svg
@@ -1,0 +1,17 @@
+<svg width="72" height="106" viewBox="0 0 72 106" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1_4534)">
+<path d="M70.7498 0.75H20.5898V86.46H70.7498V0.75Z" fill="#EC0037" stroke="#121212" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M47.3496 86.4609V88.7209C47.3496 94.2809 43.6496 98.7909 39.0996 98.7909V104.451" stroke="#121212" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14.0801 79.3619L28.2001 65.2419C30.2101 63.2319 33.4801 63.2319 35.4901 65.2419C37.5001 67.2519 37.5001 70.5219 35.4901 72.5319L23.1601 84.8619C25.6501 85.5519 27.5401 88.8019 27.5401 92.6919C27.5401 93.4619 27.4701 94.2019 27.3301 94.9019" fill="white"/>
+<path d="M14.0801 79.3619L28.2001 65.2419C30.2101 63.2319 33.4801 63.2319 35.4901 65.2419C37.5001 67.2519 37.5001 70.5219 35.4901 72.5319L23.1601 84.8619C25.6501 85.5519 27.5401 88.8019 27.5401 92.6919C27.5401 93.4619 27.4701 94.2019 27.3301 94.9019" stroke="#121212" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8.08984 104.441V80.5308C8.08984 75.6708 9.97984 70.9808 13.3898 67.5208C15.6998 65.1808 18.3798 62.7508 20.5898 61.5508" stroke="#121212" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M0.75 104.441H47.11" stroke="#121212" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M45.6699 33.8594V46.4194" stroke="#121212" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M45.75 51.5C46.3023 51.5 46.75 51.0523 46.75 50.5C46.75 49.9477 46.3023 49.5 45.75 49.5C45.1977 49.5 44.75 49.9477 44.75 50.5C44.75 51.0523 45.1977 51.5 45.75 51.5Z" fill="#121212"/>
+</g>
+<defs>
+<clipPath id="clip0_1_4534">
+<rect width="71.5" height="105.19" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/assets/cheating/warning.svg
+++ b/src/assets/cheating/warning.svg
@@ -1,0 +1,17 @@
+<svg width="72" height="106" viewBox="0 0 72 106" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1_4506)">
+<path d="M70.7498 0.75H20.5898V86.46H70.7498V0.75Z" fill="#FFAE00" stroke="#121212" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M47.3496 86.4609V88.7209C47.3496 94.2809 43.6496 98.7909 39.0996 98.7909V104.451" stroke="#121212" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14.0801 79.3619L28.2001 65.2419C30.2101 63.2319 33.4801 63.2319 35.4901 65.2419C37.5001 67.2519 37.5001 70.5219 35.4901 72.5319L23.1601 84.8619C25.6501 85.5519 27.5401 88.8019 27.5401 92.6919C27.5401 93.4619 27.4701 94.2019 27.3301 94.9019" fill="white"/>
+<path d="M14.0801 79.3619L28.2001 65.2419C30.2101 63.2319 33.4801 63.2319 35.4901 65.2419C37.5001 67.2519 37.5001 70.5219 35.4901 72.5319L23.1601 84.8619C25.6501 85.5519 27.5401 88.8019 27.5401 92.6919C27.5401 93.4619 27.4701 94.2019 27.3301 94.9019" stroke="#121212" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8.08984 104.441V80.5308C8.08984 75.6708 9.97984 70.9808 13.3898 67.5208C15.6998 65.1808 18.3798 62.7508 20.5898 61.5508" stroke="#121212" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M0.75 104.441H47.11" stroke="#121212" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M45.6699 33.8594V46.4194" stroke="#121212" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M45.75 51.5C46.3023 51.5 46.75 51.0523 46.75 50.5C46.75 49.9477 46.3023 49.5 45.75 49.5C45.1977 49.5 44.75 49.9477 44.75 50.5C44.75 51.0523 45.1977 51.5 45.75 51.5Z" fill="#121212"/>
+</g>
+<defs>
+<clipPath id="clip0_1_4506">
+<rect width="71.5" height="105.19" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/components/quiz/CheatingWarningModal/CheatingWarningModal.tsx
+++ b/src/components/quiz/CheatingWarningModal/CheatingWarningModal.tsx
@@ -1,0 +1,100 @@
+import { Modal } from '@/components/common/Modal'
+import { Button } from '@/components/common/Button'
+import warningSvg from '@/assets/cheating/warning.svg'
+import exitSvg from '@/assets/cheating/exit.svg'
+
+interface CheatingWarningModalProps {
+  count: number
+  isOpen: boolean
+  onConfirm: () => void
+  onClose: () => void
+}
+
+const MESSAGES: Record<1 | 2 | 3, { lines: string[]; button: string }> = {
+  1: {
+    lines: [
+      '다른 화면으로 이동했어요.',
+      '부정행위로 간주되며, 누적 시 시험이 종료될 수 있어요.',
+    ],
+    button: '확인',
+  },
+  2: {
+    lines: [
+      '한 번 더 화면을 이탈했어요.',
+      '3회 이상 감지되면 시험이 자동 종료됩니다.',
+    ],
+    button: '확인',
+  },
+  3: {
+    lines: [
+      '세 번째 이탈이 감지됐어요.',
+      '부정행위로 처리되어 시험이 종료됩니다.',
+    ],
+    button: '시험종료',
+  },
+}
+
+function ModalIcon({ count }: { count: 1 | 2 | 3 }) {
+  if (count >= 3)
+    return (
+      <img
+        src={exitSvg}
+        alt=""
+        aria-hidden="true"
+        className="h-[106px] w-[72px]"
+      />
+    )
+  return (
+    <img
+      src={warningSvg}
+      alt=""
+      aria-hidden="true"
+      className="h-[106px] w-[72px]"
+    />
+  )
+}
+
+function ModalTitle({ count }: { count: 1 | 2 | 3 }) {
+  const accentColor = count >= 3 ? 'text-error' : 'text-warning'
+  return (
+    <h3 className="text-text-heading text-xl leading-normal font-semibold tracking-[-0.03em]">
+      부정행위 <span className={accentColor}>{count}회</span> 감지
+    </h3>
+  )
+}
+
+export function CheatingWarningModal({
+  count,
+  isOpen,
+  onConfirm,
+  onClose,
+}: CheatingWarningModalProps) {
+  const safeCount = Math.max(1, Math.min(count, 3)) as 1 | 2 | 3
+  const msg = MESSAGES[safeCount]
+  const final = count >= 3
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={final ? onConfirm : onClose}
+      maxWidth="max-w-md"
+    >
+      <div className="flex flex-col items-center gap-6 py-4 text-center">
+        <ModalIcon count={safeCount} />
+
+        <div className="flex flex-col gap-2">
+          <ModalTitle count={safeCount} />
+          <div className="text-text-body flex flex-col text-base leading-normal">
+            {msg.lines.map((line, i) => (
+              <p key={i}>{line}</p>
+            ))}
+          </div>
+        </div>
+
+        <Button variant="primary" size="lg" fullWidth onClick={onConfirm}>
+          {msg.button}
+        </Button>
+      </div>
+    </Modal>
+  )
+}

--- a/src/components/quiz/CheatingWarningModal/index.ts
+++ b/src/components/quiz/CheatingWarningModal/index.ts
@@ -1,0 +1,1 @@
+export { CheatingWarningModal } from './CheatingWarningModal'

--- a/src/components/quiz/ExamHeader/ExamHeader.tsx
+++ b/src/components/quiz/ExamHeader/ExamHeader.tsx
@@ -1,0 +1,108 @@
+import { ArrowLeft } from 'lucide-react'
+
+interface ExamHeaderProps {
+  examTitle: string
+  formattedTime: string
+  remainingSeconds: number
+  cheatingCount: number
+  onBack: () => void
+}
+
+export function ExamHeader({
+  examTitle,
+  formattedTime,
+  remainingSeconds,
+  cheatingCount,
+  onBack,
+}: ExamHeaderProps) {
+  const isUrgent = remainingSeconds > 0 && remainingSeconds <= 60
+  const [minutes, seconds] = formattedTime.split(':')
+
+  const timerColor = isUrgent ? 'text-error' : 'text-primary'
+
+  return (
+    <header className="border-gray-350 fixed top-0 right-0 left-0 z-40 border-b bg-gray-100">
+      {/* 스크린리더용 부정행위 카운트 실시간 알림 */}
+      <span className="sr-only" role="status" aria-live="polite">
+        {cheatingCount > 0 ? `부정행위 ${cheatingCount}회 감지됨` : ''}
+      </span>
+
+      <div className="max-w-container mx-auto flex h-[128px] items-center justify-between px-6">
+        {/* 좌측: 뒤로가기 + 시험 제목 + 부제 */}
+        <div className="flex items-start gap-3">
+          <button
+            type="button"
+            onClick={onBack}
+            aria-label="시험 목록으로 돌아가기"
+            className="mt-1 shrink-0 text-gray-900"
+          >
+            <ArrowLeft size={24} aria-hidden="true" />
+          </button>
+          <div className="flex flex-col gap-5 py-1">
+            <span className="text-xl leading-normal font-semibold tracking-[-0.03em] text-gray-900">
+              {examTitle}
+            </span>
+            <span className="text-base leading-normal font-normal tracking-[-0.03em] text-gray-600">
+              집중해서 천천히, 끝까지 응시해 주세요. 응원할게요 💪
+            </span>
+          </div>
+        </div>
+
+        {/* 우측: 타이머 + 부정행위 */}
+        <div className="flex items-center gap-6">
+          {/* 타이머 pill */}
+          <div className="border-disable flex items-center gap-[2px] rounded-full border bg-white px-4 py-4">
+            <span
+              className={`text-lg leading-normal font-semibold tracking-[-0.03em] ${timerColor}`}
+            >
+              {minutes}
+            </span>
+            <span className={`text-lg font-semibold ${timerColor}`}>:</span>
+            <span
+              className={`text-lg leading-normal font-semibold tracking-[-0.03em] ${timerColor}`}
+            >
+              {seconds}
+            </span>
+            <span
+              className={`ml-2 text-lg leading-normal font-semibold tracking-[-0.03em] ${timerColor}`}
+            >
+              뒤에 끝나요
+            </span>
+          </div>
+
+          {/* 부정행위 pill */}
+          <div
+            className="border-disable flex items-center gap-[14px] rounded-full border bg-white px-4 py-4"
+            aria-label={`부정행위 ${cheatingCount}회 감지됨`}
+          >
+            <span
+              className="text-lg leading-normal font-semibold tracking-[-0.03em] text-gray-700"
+              aria-hidden="true"
+            >
+              부정행위
+            </span>
+            <div className="flex gap-2" aria-hidden="true">
+              {[1, 2, 3].map((n) => {
+                const filled = cheatingCount >= n
+                const isDanger = n === 3 && filled
+                return (
+                  <span
+                    key={n}
+                    className={[
+                      'inline-block h-[26.667px] w-5 rounded-sm border-[1.5px]',
+                      isDanger
+                        ? 'border-error bg-error'
+                        : filled
+                          ? 'border-warning bg-warning'
+                          : 'border-gray-350 bg-gray-100',
+                    ].join(' ')}
+                  />
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/src/components/quiz/ExamHeader/index.ts
+++ b/src/components/quiz/ExamHeader/index.ts
@@ -1,0 +1,1 @@
+export { ExamHeader } from './ExamHeader'

--- a/src/components/quiz/ExamSubmitModal/ExamSubmitModal.tsx
+++ b/src/components/quiz/ExamSubmitModal/ExamSubmitModal.tsx
@@ -1,0 +1,37 @@
+import { Check } from 'lucide-react'
+import { Modal } from '@/components/common/Modal'
+import { Button } from '@/components/common/Button'
+
+interface ExamSubmitModalProps {
+  isOpen: boolean
+  onConfirm: () => void
+}
+
+export function ExamSubmitModal({ isOpen, onConfirm }: ExamSubmitModalProps) {
+  return (
+    <Modal isOpen={isOpen} onClose={onConfirm} maxWidth="max-w-md">
+      <div className="flex flex-col items-center gap-6 py-4 text-center">
+        {/* 아이콘 */}
+        <div className="bg-success flex h-20 w-20 items-center justify-center rounded-full">
+          <Check size={40} stroke="white" aria-hidden="true" />
+        </div>
+
+        {/* 타이틀 */}
+        <div className="flex flex-col gap-3">
+          <h3 className="text-text-heading text-xl leading-normal font-semibold tracking-[-0.03em]">
+            시험 제출이 <span className="text-success">완료</span> 되었습니다
+          </h3>
+          <div className="text-text-body flex flex-col text-base leading-normal">
+            <p>시험이 종료 되었습니다</p>
+            <p>시험 제출이 완료 되었습니다!</p>
+            <p>정답 확인 페이지로 넘어갑니다.</p>
+          </div>
+        </div>
+
+        <Button variant="primary" size="lg" fullWidth onClick={onConfirm}>
+          확인
+        </Button>
+      </div>
+    </Modal>
+  )
+}

--- a/src/components/quiz/ExamSubmitModal/index.ts
+++ b/src/components/quiz/ExamSubmitModal/index.ts
@@ -1,0 +1,1 @@
+export { ExamSubmitModal } from './ExamSubmitModal'

--- a/src/components/quiz/FillBlankQuestion/FillBlankQuestion.tsx
+++ b/src/components/quiz/FillBlankQuestion/FillBlankQuestion.tsx
@@ -1,0 +1,62 @@
+interface FillBlankQuestionProps {
+  prompt: string
+  blankCount: number
+  answer: string[]
+  onChange: (answer: string[]) => void
+}
+
+export function FillBlankQuestion({
+  prompt,
+  answer,
+  onChange,
+}: FillBlankQuestionProps) {
+  const segments = prompt.split('[blank]')
+
+  const handleChange = (index: number, value: string) => {
+    const next = [...answer]
+    next[index] = value
+    onChange(next)
+  }
+
+  return (
+    <div className="flex max-w-[648px] flex-col gap-5">
+      {/* 지문: [blank] → (A) ________ 볼드 표시 */}
+      <div className="bg-bg-prompt rounded px-4 py-5">
+        <p className="text-base leading-normal tracking-[-0.03em] whitespace-pre-wrap text-gray-800">
+          {segments.map((segment, i) => (
+            <span key={i}>
+              {segment}
+              {i < segments.length - 1 && (
+                <strong className="font-bold">
+                  ({String.fromCharCode(65 + i)}) ________
+                </strong>
+              )}
+            </span>
+          ))}
+        </p>
+      </div>
+
+      {/* 빈칸 입력: A, B, C... 라벨 포함 */}
+      <div className="flex flex-col gap-3">
+        {answer.map((val, i) => (
+          <div
+            key={i}
+            className="bg-bg-muted flex h-12 max-w-[308px] items-center gap-2 rounded px-4 py-[10px]"
+          >
+            <span className="shrink-0 text-base leading-normal font-semibold tracking-[-0.03em] text-gray-800">
+              {String.fromCharCode(65 + i)}
+            </span>
+            <input
+              type="text"
+              value={val}
+              onChange={(e) => handleChange(i, e.target.value)}
+              placeholder="정답을 입력해 주세요."
+              aria-label={`빈칸 ${String.fromCharCode(65 + i)}`}
+              className="placeholder:text-gray-350 flex-1 bg-transparent text-base leading-normal tracking-[-0.03em] text-gray-800 outline-none"
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/quiz/FillBlankQuestion/index.ts
+++ b/src/components/quiz/FillBlankQuestion/index.ts
@@ -1,0 +1,1 @@
+export { FillBlankQuestion } from './FillBlankQuestion'

--- a/src/components/quiz/MultipleChoiceQuestion/MultipleChoiceQuestion.tsx
+++ b/src/components/quiz/MultipleChoiceQuestion/MultipleChoiceQuestion.tsx
@@ -1,0 +1,69 @@
+interface MultipleChoiceQuestionProps {
+  options: string[]
+  answer: string[]
+  onChange: (answer: string[]) => void
+}
+
+export function MultipleChoiceQuestion({
+  options,
+  answer,
+  onChange,
+}: MultipleChoiceQuestionProps) {
+  const toggle = (option: string) => {
+    if (answer.includes(option)) {
+      onChange(answer.filter((a) => a !== option))
+    } else {
+      onChange([...answer, option])
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {options.map((option, index) => {
+        const isSelected = answer.includes(option)
+        return (
+          <button
+            key={index}
+            type="button"
+            onClick={() => toggle(option)}
+            className="flex items-center gap-3 text-left"
+            aria-pressed={isSelected}
+          >
+            {/* 체크박스 */}
+            <span
+              className={[
+                'flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-sm border transition-colors',
+                isSelected
+                  ? 'border-primary bg-primary'
+                  : 'border-gray-350 bg-white',
+              ].join(' ')}
+            >
+              {isSelected && (
+                <svg
+                  width="10"
+                  height="8"
+                  viewBox="0 0 10 8"
+                  fill="none"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M1 4L3.5 6.5L9 1"
+                    stroke="white"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              )}
+            </span>
+
+            {/* 옵션 텍스트 */}
+            <span className="text-base leading-normal tracking-[-0.03em] text-gray-800">
+              {option}
+            </span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/quiz/MultipleChoiceQuestion/index.ts
+++ b/src/components/quiz/MultipleChoiceQuestion/index.ts
@@ -1,0 +1,1 @@
+export { MultipleChoiceQuestion } from './MultipleChoiceQuestion'

--- a/src/components/quiz/OXQuestion/OXQuestion.tsx
+++ b/src/components/quiz/OXQuestion/OXQuestion.tsx
@@ -1,0 +1,79 @@
+import { Circle, X, Check } from 'lucide-react'
+
+const OX_CONFIG = [
+  { value: 'O', label: '맞아요' },
+  { value: 'X', label: '아니에요' },
+] as const
+
+interface OXQuestionProps {
+  answer: string
+  onChange: (answer: string) => void
+}
+
+export function OXQuestion({ answer, onChange }: OXQuestionProps) {
+  return (
+    <div className="flex max-w-[308px] flex-col gap-3">
+      {OX_CONFIG.map(({ value, label }) => {
+        const isSelected = answer === value
+        const isO = value === 'O'
+
+        return (
+          <button
+            key={value}
+            type="button"
+            onClick={() => onChange(value)}
+            className={[
+              'flex h-12 items-center gap-2 rounded px-4 py-[10px] transition-colors duration-150',
+              isSelected
+                ? 'bg-primary-100 border-primary border'
+                : 'bg-bg-muted',
+            ].join(' ')}
+            aria-pressed={isSelected}
+          >
+            {/* O / X 아이콘 — currentColor로 부모 text 색상 참조 */}
+            <span
+              className={
+                isSelected
+                  ? isO
+                    ? 'text-success'
+                    : 'text-error'
+                  : 'text-gray-350'
+              }
+            >
+              {isO ? (
+                <Circle
+                  size={20}
+                  aria-hidden="true"
+                  stroke="currentColor"
+                  fill="none"
+                />
+              ) : (
+                <X size={20} aria-hidden="true" stroke="currentColor" />
+              )}
+            </span>
+
+            {/* 레이블 */}
+            <span
+              className={[
+                'flex-1 text-base leading-normal tracking-[-0.03em]',
+                isSelected ? 'text-primary' : 'text-gray-800',
+              ].join(' ')}
+            >
+              {label}
+            </span>
+
+            {/* 체크마크 */}
+            <span className={isSelected ? 'text-primary' : 'text-gray-350'}>
+              <Check
+                size={20}
+                aria-hidden="true"
+                stroke="currentColor"
+                className="transition-colors duration-150"
+              />
+            </span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/quiz/OXQuestion/index.ts
+++ b/src/components/quiz/OXQuestion/index.ts
@@ -1,0 +1,1 @@
+export { OXQuestion } from './OXQuestion'

--- a/src/components/quiz/OrderingQuestion/OrderingQuestion.tsx
+++ b/src/components/quiz/OrderingQuestion/OrderingQuestion.tsx
@@ -1,0 +1,256 @@
+import { useState } from 'react'
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+  useDraggable,
+  useDroppable,
+  type DragEndEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core'
+import { CSS } from '@dnd-kit/utilities'
+
+interface OrderingQuestionProps {
+  options: string[]
+  answer: string[]
+  onChange: (answer: string[]) => void
+}
+
+type DragData =
+  | { type: 'source'; item: string }
+  | { type: 'slot'; item: string; slotIndex: number }
+
+function SourceItem({
+  item,
+  label,
+  isPlaced,
+}: {
+  item: string
+  label: string
+  isPlaced: boolean
+}) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useDraggable({
+      id: `source::${item}`,
+      data: { type: 'source', item } satisfies DragData,
+      disabled: isPlaced,
+    })
+
+  const style = transform
+    ? { transform: CSS.Translate.toString(transform) }
+    : undefined
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={[
+        'flex items-center gap-2',
+        isPlaced
+          ? 'cursor-not-allowed opacity-40'
+          : 'cursor-grab active:cursor-grabbing',
+        isDragging ? 'opacity-0' : '',
+      ].join(' ')}
+      {...(!isPlaced ? { ...listeners, ...attributes } : {})}
+    >
+      <div className="bg-primary-100 flex h-8 w-8 shrink-0 items-center justify-center rounded">
+        <span
+          className={[
+            'text-base leading-normal font-semibold',
+            isPlaced ? 'text-gray-350' : 'text-primary',
+          ].join(' ')}
+        >
+          {label}
+        </span>
+      </div>
+      <span
+        className={[
+          'flex-1 text-base leading-normal tracking-[-0.03em]',
+          isPlaced ? 'text-gray-350' : 'text-gray-800',
+        ].join(' ')}
+      >
+        {item}
+      </span>
+    </div>
+  )
+}
+
+function SlotItem({
+  item,
+  slotIndex,
+  label,
+  onRemove,
+}: {
+  item: string
+  slotIndex: number
+  label: string
+  onRemove: () => void
+}) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useDraggable({
+      id: `slot::${slotIndex}`,
+      data: { type: 'slot', item, slotIndex } satisfies DragData,
+    })
+
+  const style = transform
+    ? { transform: CSS.Translate.toString(transform) }
+    : undefined
+
+  return (
+    <button
+      ref={setNodeRef}
+      style={style}
+      type="button"
+      onClick={onRemove}
+      aria-label={`슬롯 ${slotIndex + 1}: ${item} 제거`}
+      className={[
+        'bg-primary-100 flex h-[62px] w-[62px] cursor-grab items-center justify-center rounded transition-opacity active:cursor-grabbing',
+        isDragging ? 'opacity-0' : '',
+      ].join(' ')}
+      {...listeners}
+      {...attributes}
+    >
+      <span className="text-primary text-[18px] font-semibold">{label}</span>
+    </button>
+  )
+}
+
+function DropSlot({
+  slotIndex,
+  children,
+}: {
+  slotIndex: number
+  children?: React.ReactNode
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: `dropslot::${slotIndex}` })
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={[
+        'flex h-[62px] w-[62px] items-center justify-center rounded border-2 transition-colors duration-150',
+        isOver
+          ? 'border-primary bg-primary-100 border-dashed'
+          : 'bg-bg-muted border-transparent',
+      ].join(' ')}
+    >
+      {children}
+    </div>
+  )
+}
+
+export function OrderingQuestion({
+  options,
+  answer,
+  onChange,
+}: OrderingQuestionProps) {
+  const [activeData, setActiveData] = useState<{ label: string } | null>(null)
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 200, tolerance: 5 },
+    })
+  )
+
+  // 항상 options.length 크기의 배열 유지, 빈 슬롯은 ''
+  const slots: string[] = [
+    ...answer,
+    ...Array(Math.max(0, options.length - answer.length)).fill(''),
+  ].slice(0, options.length)
+
+  const placed = new Set(slots.filter(Boolean))
+
+  const getLetter = (item: string) => {
+    const idx = options.indexOf(item)
+    return idx >= 0 ? String.fromCharCode(65 + idx) : '?'
+  }
+
+  const handleDragStart = ({ active }: DragStartEvent) => {
+    const data = active.data.current as DragData
+    setActiveData({ label: getLetter(data.item) })
+  }
+
+  const handleDragEnd = ({ active, over }: DragEndEvent) => {
+    setActiveData(null)
+    if (!over) return
+
+    const overId = over.id as string
+    if (!overId.startsWith('dropslot::')) return
+
+    const targetSlot = parseInt(overId.replace('dropslot::', ''), 10)
+    const data = active.data.current as DragData
+    const next = [...slots]
+
+    if (data.type === 'source') {
+      if (placed.has(data.item)) return
+      next[targetSlot] = data.item
+    } else if (data.type === 'slot') {
+      const fromSlot = data.slotIndex
+      if (fromSlot === targetSlot) return // 두 슬롯 swap
+      ;[next[fromSlot], next[targetSlot]] = [next[targetSlot], next[fromSlot]]
+    }
+
+    onChange(next)
+  }
+
+  const handleRemoveSlot = (slotIndex: number) => {
+    const next = [...slots]
+    next[slotIndex] = ''
+    onChange(next)
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+    >
+      <div className="flex flex-col gap-5">
+        {/* 선택지 목록 */}
+        <div className="bg-bg-prompt max-w-[648px] rounded px-4 py-5">
+          <div className="flex flex-col gap-5">
+            {options.map((item, i) => (
+              <SourceItem
+                key={item}
+                item={item}
+                label={String.fromCharCode(65 + i)}
+                isPlaced={placed.has(item)}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* 순서 슬롯 */}
+        <div className="flex gap-[10px]">
+          {slots.map((placedItem, i) => (
+            <DropSlot key={i} slotIndex={i}>
+              {placedItem ? (
+                <SlotItem
+                  item={placedItem}
+                  slotIndex={i}
+                  label={getLetter(placedItem)}
+                  onRemove={() => handleRemoveSlot(i)}
+                />
+              ) : null}
+            </DropSlot>
+          ))}
+        </div>
+      </div>
+
+      {/* 드래그 중 미리보기 */}
+      <DragOverlay>
+        {activeData && (
+          <div className="bg-primary-100 flex h-[62px] w-[62px] cursor-grabbing items-center justify-center rounded opacity-90 shadow-lg">
+            <span className="text-primary text-[18px] font-semibold">
+              {activeData.label}
+            </span>
+          </div>
+        )}
+      </DragOverlay>
+    </DndContext>
+  )
+}

--- a/src/components/quiz/OrderingQuestion/index.ts
+++ b/src/components/quiz/OrderingQuestion/index.ts
@@ -1,0 +1,1 @@
+export { OrderingQuestion } from './OrderingQuestion'

--- a/src/components/quiz/QuestionCard/QuestionCard.tsx
+++ b/src/components/quiz/QuestionCard/QuestionCard.tsx
@@ -1,0 +1,111 @@
+import { OXQuestion } from '@/components/quiz/OXQuestion'
+import { SingleChoiceQuestion } from '@/components/quiz/SingleChoiceQuestion'
+import { MultipleChoiceQuestion } from '@/components/quiz/MultipleChoiceQuestion'
+import { ShortAnswerQuestion } from '@/components/quiz/ShortAnswerQuestion'
+import { OrderingQuestion } from '@/components/quiz/OrderingQuestion'
+import { FillBlankQuestion } from '@/components/quiz/FillBlankQuestion'
+import type { Question } from '@/features/exams/deployment-detail'
+
+const TYPE_LABELS: Record<Question['type'], string> = {
+  ox: 'OX선택',
+  single_choice: '단일선택',
+  multiple_choice: '다중선택',
+  short_answer: '단답형',
+  ordering: '순서배열',
+  fill_blank: '빈칸식',
+}
+
+interface QuestionCardProps {
+  question: Question
+  answer: string | string[]
+  onChange: (answer: string | string[]) => void
+}
+
+export function QuestionCard({
+  question,
+  answer,
+  onChange,
+}: QuestionCardProps) {
+  const renderInput = () => {
+    switch (question.type) {
+      case 'ox':
+      case 'single_choice':
+      case 'short_answer': {
+        if (typeof answer !== 'string') return null
+        if (question.type === 'ox') {
+          return <OXQuestion answer={answer} onChange={onChange} />
+        }
+        if (question.type === 'single_choice') {
+          return (
+            <SingleChoiceQuestion
+              options={question.options ?? []}
+              answer={answer}
+              onChange={onChange}
+            />
+          )
+        }
+        return <ShortAnswerQuestion answer={answer} onChange={onChange} />
+      }
+      case 'multiple_choice':
+      case 'ordering':
+      case 'fill_blank': {
+        if (!Array.isArray(answer)) return null
+        if (question.type === 'multiple_choice') {
+          return (
+            <MultipleChoiceQuestion
+              options={question.options ?? []}
+              answer={answer}
+              onChange={onChange}
+            />
+          )
+        }
+        if (question.type === 'ordering') {
+          return (
+            <OrderingQuestion
+              options={question.options ?? []}
+              answer={answer}
+              onChange={onChange}
+            />
+          )
+        }
+        return (
+          <FillBlankQuestion
+            prompt={question.prompt ?? ''}
+            blankCount={question.blank_count ?? 0}
+            answer={answer}
+            onChange={onChange}
+          />
+        )
+      }
+      default:
+        return null
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      {/* 헤더: 번호 + 문제 텍스트 + 배점/유형 뱃지 */}
+      <div className="flex items-start gap-4">
+        <div className="flex flex-1 items-start py-1">
+          <span className="w-8 shrink-0 text-xl leading-normal font-bold tracking-[-0.03em] text-gray-900">
+            {question.number}.
+          </span>
+          <p className="text-xl leading-normal font-bold tracking-[-0.03em] text-gray-900">
+            {question.question}
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <span className="bg-disable rounded-sm px-3 py-2 text-xs leading-normal tracking-[-0.03em] whitespace-nowrap text-gray-900">
+            {question.point}점
+          </span>
+          <span className="bg-disable rounded-sm px-3 py-2 text-xs leading-normal tracking-[-0.03em] whitespace-nowrap text-gray-900">
+            {TYPE_LABELS[question.type]}
+          </span>
+        </div>
+      </div>
+
+      {/* 답안 입력 — 번호(32px) 너비만큼 들여쓰기 */}
+      <div className="pl-8">{renderInput()}</div>
+    </div>
+  )
+}

--- a/src/components/quiz/QuestionCard/index.ts
+++ b/src/components/quiz/QuestionCard/index.ts
@@ -1,0 +1,1 @@
+export { QuestionCard } from './QuestionCard'

--- a/src/components/quiz/ShortAnswerQuestion/ShortAnswerQuestion.tsx
+++ b/src/components/quiz/ShortAnswerQuestion/ShortAnswerQuestion.tsx
@@ -1,0 +1,21 @@
+interface ShortAnswerQuestionProps {
+  answer: string
+  onChange: (answer: string) => void
+}
+
+export function ShortAnswerQuestion({
+  answer,
+  onChange,
+}: ShortAnswerQuestionProps) {
+  return (
+    <div className="max-w-[648px]">
+      <input
+        type="text"
+        value={answer}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="20글자 이내로 입력해 주세요."
+        className="bg-bg-muted placeholder:text-gray-350 h-12 w-full rounded px-4 py-[10px] text-base leading-normal tracking-[-0.03em] text-gray-800 outline-none"
+      />
+    </div>
+  )
+}

--- a/src/components/quiz/ShortAnswerQuestion/index.ts
+++ b/src/components/quiz/ShortAnswerQuestion/index.ts
@@ -1,0 +1,1 @@
+export { ShortAnswerQuestion } from './ShortAnswerQuestion'

--- a/src/components/quiz/SingleChoiceQuestion/SingleChoiceQuestion.tsx
+++ b/src/components/quiz/SingleChoiceQuestion/SingleChoiceQuestion.tsx
@@ -1,0 +1,45 @@
+interface SingleChoiceQuestionProps {
+  options: string[]
+  answer: string
+  onChange: (answer: string) => void
+}
+
+export function SingleChoiceQuestion({
+  options,
+  answer,
+  onChange,
+}: SingleChoiceQuestionProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      {options.map((option, index) => {
+        const isSelected = answer === option
+        return (
+          <button
+            key={index}
+            type="button"
+            onClick={() => onChange(option)}
+            className="flex items-center gap-3 text-left"
+            aria-pressed={isSelected}
+          >
+            {/* 라디오 원 */}
+            <span
+              className={[
+                'flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full border-2 transition-colors',
+                isSelected
+                  ? 'border-primary bg-primary'
+                  : 'border-gray-350 bg-white',
+              ].join(' ')}
+            >
+              {isSelected && <span className="h-2 w-2 rounded-full bg-white" />}
+            </span>
+
+            {/* 옵션 텍스트 */}
+            <span className="text-base leading-normal tracking-[-0.03em] text-gray-800">
+              {option}
+            </span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/quiz/SingleChoiceQuestion/index.ts
+++ b/src/components/quiz/SingleChoiceQuestion/index.ts
@@ -1,0 +1,1 @@
+export { SingleChoiceQuestion } from './SingleChoiceQuestion'

--- a/src/constants/httpStatus.ts
+++ b/src/constants/httpStatus.ts
@@ -7,5 +7,6 @@ export const HTTP_STATUS = {
   NOT_FOUND: 404,
   CONFLICT: 409,
   LOCKED: 423,
+  GONE: 410,
   INTERNAL_SERVER_ERROR: 500,
 } as const

--- a/src/features/exams/deployment-detail/handler.ts
+++ b/src/features/exams/deployment-detail/handler.ts
@@ -1,0 +1,92 @@
+import { http, HttpResponse } from 'msw'
+import type { DeploymentDetailResponse } from './types'
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
+
+const mockDetail: DeploymentDetailResponse = {
+  exam_id: 2,
+  exam_title: 'JavaScript 심화 쪽지시험',
+  duration_time: 30,
+  elapsed_time: 0,
+  cheating_count: 0,
+  questions: [
+    {
+      question_id: 1,
+      number: 1,
+      type: 'ox',
+      question: 'JavaScript에서 null == undefined는 true이다.',
+      point: 10,
+      prompt: null,
+      blank_count: null,
+      options: ['O', 'X'],
+      answer_input: null,
+    },
+    {
+      question_id: 2,
+      number: 2,
+      type: 'single_choice',
+      question: 'Array.prototype.map()의 반환값은 무엇인가?',
+      point: 10,
+      prompt: null,
+      blank_count: null,
+      options: ['새로운 배열', '원본 배열', 'undefined', 'null'],
+      answer_input: null,
+    },
+    {
+      question_id: 3,
+      number: 3,
+      type: 'multiple_choice',
+      question:
+        '다음 중 JavaScript의 원시 타입(Primitive type)에 해당하는 것을 모두 고르시오.',
+      point: 10,
+      prompt: null,
+      blank_count: null,
+      options: ['string', 'object', 'number', 'symbol', 'array'],
+      answer_input: null,
+    },
+    {
+      question_id: 4,
+      number: 4,
+      type: 'short_answer',
+      question: 'Promise의 세 가지 상태를 쉼표로 구분하여 적으시오.',
+      point: 10,
+      prompt: null,
+      blank_count: null,
+      options: null,
+      answer_input: null,
+    },
+    {
+      question_id: 5,
+      number: 5,
+      type: 'fill_blank',
+      question: '다음 문장의 빈칸을 채우시오.',
+      point: 10,
+      prompt:
+        '자바스크립트에서 [blank]는 값이 없음을 의미하고, [blank]는 존재하지 않음을 의미한다.',
+      blank_count: 2,
+      options: null,
+      answer_input: ['', ''],
+    },
+    {
+      question_id: 6,
+      number: 6,
+      type: 'ordering',
+      question: '다음 Promise 실행 순서를 올바르게 배열하시오.',
+      point: 10,
+      prompt: null,
+      blank_count: null,
+      options: ['콜백 등록', 'resolve 호출', 'Promise 생성', 'then 실행'],
+      answer_input: null,
+    },
+  ],
+}
+
+// GET /api/v1/exams/deployments/:deploymentId — 쪽지시험 문제 조회 API
+export const deploymentDetailHandlers = [
+  http.get(`${BASE_URL}/exams/deployments/:deploymentId`, ({ request }) => {
+    const url = new URL(request.url)
+    // check-code 서브패스는 별도 핸들러에서 처리
+    if (url.pathname.endsWith('check-code')) return
+    return HttpResponse.json<DeploymentDetailResponse>(mockDetail)
+  }),
+]

--- a/src/features/exams/deployment-detail/index.ts
+++ b/src/features/exams/deployment-detail/index.ts
@@ -1,0 +1,3 @@
+export type { QuestionType, Question, DeploymentDetailResponse } from './types'
+export { deploymentDetailQueries, useDeploymentDetail } from './queries'
+export { deploymentDetailHandlers } from './handler'

--- a/src/features/exams/deployment-detail/queries.ts
+++ b/src/features/exams/deployment-detail/queries.ts
@@ -1,0 +1,20 @@
+import { queryOptions, useSuspenseQuery } from '@tanstack/react-query'
+import api from '@/api/instance'
+import type { DeploymentDetailResponse } from './types'
+
+export const deploymentDetailQueries = {
+  detail: (deploymentId: number) =>
+    queryOptions({
+      queryKey: ['exams', 'deployments', deploymentId, 'detail'],
+      queryFn: async () => {
+        const { data } = await api.get<DeploymentDetailResponse>(
+          `exams/deployments/${deploymentId}`
+        )
+        return data
+      },
+    }),
+}
+
+export function useDeploymentDetail(deploymentId: number) {
+  return useSuspenseQuery(deploymentDetailQueries.detail(deploymentId))
+}

--- a/src/features/exams/deployment-detail/types.ts
+++ b/src/features/exams/deployment-detail/types.ts
@@ -1,0 +1,28 @@
+export type QuestionType =
+  | 'single_choice'
+  | 'multiple_choice'
+  | 'ox'
+  | 'short_answer'
+  | 'ordering'
+  | 'fill_blank'
+
+export interface Question {
+  question_id: number
+  number: number
+  type: QuestionType
+  question: string
+  point: number
+  prompt: string | null
+  blank_count: number | null
+  options: string[] | null
+  answer_input: string | string[] | null
+}
+
+export interface DeploymentDetailResponse {
+  exam_id: number
+  exam_title: string
+  duration_time: number
+  elapsed_time: number
+  cheating_count: number
+  questions: Question[]
+}

--- a/src/features/exams/submissions/handler.ts
+++ b/src/features/exams/submissions/handler.ts
@@ -1,0 +1,70 @@
+import { http, HttpResponse } from 'msw'
+import { HTTP_STATUS } from '@/constants/httpStatus'
+import type { SubmissionResponse } from './types'
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
+
+// POST /api/v1/exams/submissions — 답안 제출 API
+export const submissionsHandlers = [
+  http.post(`${BASE_URL}/exams/submissions`, async ({ request }) => {
+    const body = (await request.json()) as { deployment_id?: number }
+
+    // 400 — 유효하지 않은 시험 응시 세션
+    if (body.deployment_id === 997) {
+      return HttpResponse.json(
+        { error_detail: '유효하지 않은 시험 응시 세션입니다.' },
+        { status: HTTP_STATUS.BAD_REQUEST }
+      )
+    }
+
+    // 401 — 인증 실패
+    if (body.deployment_id === 996) {
+      return HttpResponse.json(
+        { error_detail: '자격 인증 데이터가 제공되지 않았습니다.' },
+        { status: HTTP_STATUS.UNAUTHORIZED }
+      )
+    }
+
+    // 403 — 권한 없음
+    if (body.deployment_id === 995) {
+      return HttpResponse.json(
+        { error_detail: '권한이 없습니다.' },
+        { status: HTTP_STATUS.FORBIDDEN }
+      )
+    }
+
+    // 404 — 시험 없음
+    if (body.deployment_id === 994) {
+      return HttpResponse.json(
+        { error_detail: '해당 시험 정보를 찾을 수 없습니다.' },
+        { status: HTTP_STATUS.NOT_FOUND }
+      )
+    }
+
+    // 409 — 중복 제출
+    if (body.deployment_id === 999) {
+      return HttpResponse.json(
+        { error_detail: '이미 제출된 시험입니다.' },
+        { status: HTTP_STATUS.CONFLICT }
+      )
+    }
+
+    // 410 — 시험 종료됨
+    if (body.deployment_id === 998) {
+      return HttpResponse.json(
+        { error_detail: '시험이 이미 종료되었습니다.' },
+        { status: HTTP_STATUS.GONE }
+      )
+    }
+
+    return HttpResponse.json<SubmissionResponse>(
+      {
+        submission_id: 1001,
+        score: 80,
+        correct_answer_count: 5,
+        redirect_url: `/quiz/${body.deployment_id ?? 2}/result`,
+      },
+      { status: HTTP_STATUS.CREATED }
+    )
+  }),
+]

--- a/src/features/exams/submissions/index.ts
+++ b/src/features/exams/submissions/index.ts
@@ -1,0 +1,7 @@
+export type {
+  SubmissionAnswer,
+  SubmissionRequest,
+  SubmissionResponse,
+} from './types'
+export { useSubmitExam } from './queries'
+export { submissionsHandlers } from './handler'

--- a/src/features/exams/submissions/queries.ts
+++ b/src/features/exams/submissions/queries.ts
@@ -1,0 +1,17 @@
+import { useMutation } from '@tanstack/react-query'
+import api from '@/api/instance'
+import type { SubmissionRequest, SubmissionResponse } from './types'
+
+export function useSubmitExam() {
+  return useMutation({
+    mutationFn: async (body: SubmissionRequest) => {
+      const { data } = await api.post<SubmissionResponse>(
+        'exams/submissions',
+        body
+      )
+      return data
+    },
+    // 재시도 시 409(중복 제출) 유발 방지
+    retry: 0,
+  })
+}

--- a/src/features/exams/submissions/types.ts
+++ b/src/features/exams/submissions/types.ts
@@ -1,0 +1,21 @@
+import type { QuestionType } from '../deployment-detail/types'
+
+export interface SubmissionAnswer {
+  question_id: number
+  type: QuestionType
+  submitted_answer: string | string[]
+}
+
+export interface SubmissionRequest {
+  deployment_id: number
+  started_at: string
+  cheating_count: number
+  answers: SubmissionAnswer[]
+}
+
+export interface SubmissionResponse {
+  submission_id: number
+  score: number
+  correct_answer_count: number
+  redirect_url: string
+}

--- a/src/hooks/useCheatingDetector.ts
+++ b/src/hooks/useCheatingDetector.ts
@@ -1,0 +1,93 @@
+import { useState, useEffect, useRef } from 'react'
+
+interface UseCheatingDetectorOptions {
+  initialCount: number
+  onDetect: (count: number) => void
+  enabled: boolean
+}
+
+interface UseCheatingDetectorResult {
+  cheatingCount: number
+}
+
+export function useCheatingDetector({
+  initialCount,
+  onDetect,
+  enabled,
+}: UseCheatingDetectorOptions): UseCheatingDetectorResult {
+  const [cheatingCount, setCheatingCount] = useState(initialCount)
+  const onDetectRef = useRef(onDetect)
+  // 두 이벤트가 동시에 발생할 때 이중 카운트 방지용 타임스탬프
+  const lastDetectedAt = useRef(0)
+  const prevCountRef = useRef(initialCount)
+
+  useEffect(() => {
+    onDetectRef.current = onDetect
+  })
+
+  // setState 업데이터 내부에서 콜백 호출 시 Strict Mode 더블 실행 문제 방지
+  useEffect(() => {
+    if (cheatingCount > prevCountRef.current) {
+      prevCountRef.current = cheatingCount
+      onDetectRef.current(cheatingCount)
+    }
+  }, [cheatingCount])
+
+  // 시험 중 탭 종료 / 새로고침 방지
+  useEffect(() => {
+    if (!enabled) return
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault()
+      e.returnValue = ''
+    }
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
+  }, [enabled])
+
+  useEffect(() => {
+    if (!enabled) return
+
+    // 페이지 진입 직후 네비게이션/포커스 전환으로 인한 오탐 방지
+    let active = false
+    const warmup = setTimeout(() => {
+      active = true
+    }, 1000)
+
+    const detect = () => {
+      if (!active) return
+      const now = Date.now()
+      // 300ms 내 중복 이벤트 무시 (fullscreenchange + visibilitychange 동시 발생 대응)
+      if (now - lastDetectedAt.current < 300) return
+      lastDetectedAt.current = now
+      setCheatingCount((prev) => prev + 1)
+    }
+
+    // 1. 전체화면 이탈 감지 (Escape, alt+tab 등)
+    const handleFullscreenChange = () => {
+      if (!document.fullscreenElement) detect()
+    }
+
+    // 2. 탭/창 전환 감지 — 전체화면 미지원 브라우저 fallback 및 보조 감지
+    const handleVisibilityChange = () => {
+      if (document.hidden) detect()
+    }
+
+    // 3. 듀얼모니터 등 다른 앱/창 포커스 감지 — visibilitychange가 발생하지 않는 경우 보완
+    const handleWindowBlur = () => {
+      if (!document.hasFocus()) detect()
+    }
+
+    document.addEventListener('fullscreenchange', handleFullscreenChange)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    window.addEventListener('blur', handleWindowBlur)
+
+    return () => {
+      clearTimeout(warmup)
+      document.removeEventListener('fullscreenchange', handleFullscreenChange)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+      window.removeEventListener('blur', handleWindowBlur)
+    }
+  }, [enabled])
+
+  return { cheatingCount }
+}

--- a/src/hooks/useExamTimer.ts
+++ b/src/hooks/useExamTimer.ts
@@ -1,0 +1,66 @@
+import { useState, useEffect, useRef } from 'react'
+
+interface UseExamTimerOptions {
+  initialSeconds: number
+  onExpire: () => void
+}
+
+interface UseExamTimerResult {
+  remainingSeconds: number
+  formattedTime: string
+}
+
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60)
+  const s = seconds % 60
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
+}
+
+export function useExamTimer({
+  initialSeconds,
+  onExpire,
+}: UseExamTimerOptions): UseExamTimerResult {
+  const [remainingSeconds, setRemainingSeconds] = useState(
+    Math.max(0, initialSeconds)
+  )
+  const onExpireRef = useRef(onExpire)
+  // Strict Mode 더블 마운트 또는 cleanup 후 재큐잉으로 onExpire 중복 호출 방지
+  const expiredRef = useRef(false)
+  const expireTimeoutRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    onExpireRef.current = onExpire
+  })
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setRemainingSeconds((prev) => {
+        const next = prev - 1
+        if (next <= 0) {
+          clearInterval(timer)
+          if (!expiredRef.current) {
+            expiredRef.current = true
+            expireTimeoutRef.current = window.setTimeout(
+              () => onExpireRef.current(),
+              0
+            )
+          }
+          return 0
+        }
+        return next
+      })
+    }, 1000)
+
+    return () => {
+      clearInterval(timer)
+      if (expireTimeoutRef.current !== null) {
+        clearTimeout(expireTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  return {
+    remainingSeconds,
+    formattedTime: formatTime(remainingSeconds),
+  }
+}

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -6,6 +6,8 @@ import { meEnrolledCoursesHandlers } from '@/features/accounts/me-enrolled-cours
 import { checkCodeHandlers } from '@/features/exams/deployment-check-code'
 import { checkNicknameHandlers } from '@/features/accounts/check-nickname'
 import { meProfileImageHandlers } from '@/features/accounts/me-profile-image'
+import { deploymentDetailHandlers } from '@/features/exams/deployment-detail'
+import { submissionsHandlers } from '@/features/exams/submissions'
 
 export const handlers = [
   http.get('/api/health', () => {
@@ -15,7 +17,10 @@ export const handlers = [
   ...meEnrolledCoursesHandlers,
   ...deploymentsHandlers,
   ...loginHandlers,
+  // check-code는 deploymentDetail보다 먼저 등록해 패스 우선순위 확보
   ...checkCodeHandlers,
   ...checkNicknameHandlers,
   ...meProfileImageHandlers,
+  ...deploymentDetailHandlers,
+  ...submissionsHandlers,
 ]

--- a/src/pages/quiz/QuizExamPage.tsx
+++ b/src/pages/quiz/QuizExamPage.tsx
@@ -1,6 +1,349 @@
+import { Suspense, useState, useRef, useCallback, useEffect } from 'react'
+import { X } from 'lucide-react'
+import { useParams, useNavigate, Navigate } from 'react-router'
+import axios from 'axios'
+import { Button } from '@/components/common/Button'
+import { Spinner } from '@/components/common/Spinner'
+import { ExamHeader } from '@/components/quiz/ExamHeader'
+import { CheatingWarningModal } from '@/components/quiz/CheatingWarningModal'
+import { ExamSubmitModal } from '@/components/quiz/ExamSubmitModal'
+import { QuestionCard } from '@/components/quiz/QuestionCard'
+import { useDeploymentDetail } from '@/features/exams/deployment-detail'
+import { useSubmitExam } from '@/features/exams/submissions'
+import { useExamTimer } from '@/hooks/useExamTimer'
+import { useCheatingDetector } from '@/hooks/useCheatingDetector'
+import { useToastStore } from '@/stores/toastStore'
+import { HTTP_STATUS } from '@/constants/httpStatus'
+import type { Question } from '@/features/exams/deployment-detail'
+import type { SubmissionAnswer } from '@/features/exams/submissions'
+
+interface ApiErrorBody {
+  error_detail?: string
+}
+
+const ERROR_MAP: Record<number, { fallback: string; redirect?: string }> = {
+  [HTTP_STATUS.BAD_REQUEST]: {
+    fallback: '유효하지 않은 시험 응시 세션입니다.',
+    redirect: '/mypage/quiz',
+  },
+  [HTTP_STATUS.UNAUTHORIZED]: {
+    fallback: '로그인이 필요합니다.',
+    redirect: '/auth/login',
+  },
+  [HTTP_STATUS.FORBIDDEN]: {
+    fallback: '권한이 없습니다.',
+    redirect: '/mypage/quiz',
+  },
+  [HTTP_STATUS.NOT_FOUND]: {
+    fallback: '해당 시험 정보를 찾을 수 없습니다.',
+    redirect: '/mypage/quiz',
+  },
+  [HTTP_STATUS.CONFLICT]: { fallback: '이미 제출된 시험입니다.' },
+  [HTTP_STATUS.GONE]: {
+    fallback: '시험이 종료되었습니다.',
+    redirect: '/mypage/quiz',
+  },
+}
+
+function initAnswers(questions: Question[]): Record<number, string | string[]> {
+  const map: Record<number, string | string[]> = {}
+  for (const q of questions) {
+    if (
+      q.type === 'single_choice' ||
+      q.type === 'ox' ||
+      q.type === 'short_answer'
+    ) {
+      map[q.question_id] =
+        typeof q.answer_input === 'string' ? q.answer_input : ''
+    } else if (q.type === 'multiple_choice') {
+      map[q.question_id] = Array.isArray(q.answer_input) ? q.answer_input : []
+    } else if (q.type === 'ordering') {
+      map[q.question_id] = Array.isArray(q.answer_input) ? q.answer_input : []
+    } else if (q.type === 'fill_blank') {
+      map[q.question_id] = Array.isArray(q.answer_input)
+        ? q.answer_input
+        : Array<string>(q.blank_count ?? 0).fill('')
+    }
+  }
+  return map
+}
+
+function isAnswered(q: Question, answer: string | string[]): boolean {
+  if (q.type === 'ordering') {
+    const ans = answer as string[]
+    return ans.length === (q.options?.length ?? 0) && ans.every((a) => a !== '')
+  }
+  if (Array.isArray(answer))
+    return answer.length > 0 && answer.every((a) => a !== '')
+  return (answer as string).trim() !== ''
+}
+
+interface ExamContentProps {
+  deploymentId: number
+}
+
+function AlertCircleIcon() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+      className="text-error shrink-0"
+    >
+      <circle cx="12" cy="12" r="10" fill="currentColor" />
+      <path d="M12 7v6" stroke="white" strokeWidth="2" strokeLinecap="round" />
+      <circle cx="12" cy="16.5" r="1" fill="white" />
+    </svg>
+  )
+}
+
+function ExamContent({ deploymentId }: ExamContentProps) {
+  const navigate = useNavigate()
+  const showToast = useToastStore((s) => s.show)
+
+  const { data } = useDeploymentDetail(deploymentId)
+  const { mutate: submitExam, isPending: isSubmitting } = useSubmitExam()
+
+  const { exam_title, duration_time, elapsed_time, cheating_count, questions } =
+    data
+
+  const [answers, setAnswers] = useState<Record<number, string | string[]>>(
+    () => initAnswers(questions)
+  )
+  const [showWarningBanner, setShowWarningBanner] = useState(true)
+  const [warningModalCount, setWarningModalCount] = useState(0)
+  const [isSubmitted, setIsSubmitted] = useState(false)
+  const [submitRedirectUrl, setSubmitRedirectUrl] = useState<string | null>(
+    null
+  )
+  // 사용자 제스처(버튼 클릭) 이후 fullscreen 진입 및 시험 시작 상태
+  const startedAt = useRef(new Date().toISOString().slice(0, 19))
+
+  useEffect(() => {
+    document.documentElement.requestFullscreen().catch(() => {})
+    return () => {
+      if (document.fullscreenElement) {
+        document.exitFullscreen().catch(() => {})
+      }
+    }
+  }, [])
+
+  const allAnswered = questions.every((q) =>
+    isAnswered(q, answers[q.question_id])
+  )
+
+  const buildSubmissionAnswers = useCallback(
+    (currentAnswers: Record<number, string | string[]>): SubmissionAnswer[] =>
+      questions.map((q) => ({
+        question_id: q.question_id,
+        type: q.type,
+        submitted_answer: currentAnswers[q.question_id] ?? '',
+      })),
+    [questions]
+  )
+
+  const handleSubmit = useCallback(
+    (
+      currentAnswers: Record<number, string | string[]>,
+      currentCheating: number,
+      onSuccess?: (redirectUrl: string) => void
+    ) => {
+      if (isSubmitted) return
+      setIsSubmitted(true)
+
+      submitExam(
+        {
+          deployment_id: deploymentId,
+          started_at: startedAt.current,
+          cheating_count: currentCheating,
+          answers: buildSubmissionAnswers(currentAnswers),
+        },
+        {
+          onSuccess: (res) => {
+            if (onSuccess) {
+              onSuccess(res.redirect_url)
+            } else {
+              setSubmitRedirectUrl(res.redirect_url)
+            }
+          },
+          onError: (error) => {
+            setIsSubmitted(false)
+            if (!axios.isAxiosError(error)) return
+
+            const status = error.response?.status
+            const detail = (error.response?.data as ApiErrorBody | undefined)
+              ?.error_detail
+            const config = status ? ERROR_MAP[status] : undefined
+            showToast(
+              detail ?? config?.fallback ?? '서버 오류가 발생했습니다.',
+              'error'
+            )
+            if (config?.redirect) navigate(config.redirect)
+          },
+        }
+      )
+    },
+    [
+      isSubmitted,
+      deploymentId,
+      navigate,
+      showToast,
+      submitExam,
+      buildSubmissionAnswers,
+    ]
+  )
+
+  const { cheatingCount } = useCheatingDetector({
+    initialCount: cheating_count,
+    onDetect: (count) => setWarningModalCount(count),
+    enabled: !isSubmitted,
+  })
+
+  const handleTimerExpire = useCallback(() => {
+    handleSubmit(answers, cheatingCount, (url) =>
+      navigate(url, { replace: true })
+    )
+  }, [answers, cheatingCount, handleSubmit, navigate])
+
+  const { formattedTime, remainingSeconds } = useExamTimer({
+    initialSeconds: duration_time * 60 - elapsed_time,
+    onExpire: handleTimerExpire,
+  })
+
+  const handleWarningConfirm = useCallback(() => {
+    setWarningModalCount(0)
+    if (cheatingCount >= 3) {
+      handleSubmit(answers, cheatingCount, (url) =>
+        navigate(url, { replace: true })
+      )
+    } else {
+      document.documentElement.requestFullscreen().catch(() => {})
+    }
+  }, [answers, cheatingCount, handleSubmit, navigate])
+
+  const handleAnswerChange = useCallback(
+    (questionId: number, answer: string | string[]) => {
+      setAnswers((prev) => ({ ...prev, [questionId]: answer }))
+    },
+    []
+  )
+
+  const handleBack = useCallback(() => {
+    if (document.fullscreenElement) {
+      document.exitFullscreen().catch(() => {})
+    }
+    navigate('/mypage/quiz')
+  }, [navigate])
+
+  return (
+    <div className="min-h-screen bg-white">
+      <ExamHeader
+        examTitle={exam_title}
+        formattedTime={formattedTime}
+        remainingSeconds={remainingSeconds}
+        cheatingCount={cheatingCount}
+        onBack={handleBack}
+      />
+
+      {/* 헤더 높이(128px) + 여백 보정 */}
+      <main className="max-w-container mx-auto px-6 pt-[160px] pb-24">
+        {/* 부정행위 안내 배너 */}
+        {showWarningBanner && (
+          <div className="bg-primary-100 mb-6 rounded-lg px-6 py-5">
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex items-start gap-3">
+                <span className="mt-0.5 shrink-0">
+                  <AlertCircleIcon />
+                </span>
+                <div className="flex flex-col gap-5">
+                  <p className="text-lg leading-normal font-semibold tracking-[-0.03em] text-gray-900">
+                    시험에만 집중해 주세요
+                  </p>
+                  <p className="text-base leading-normal tracking-[-0.03em] text-gray-900">
+                    탭이나 창을 이동하면 부정행위로 처리돼 시험이 중단될 수
+                    있어요. 안정적인 환경에서 시험을 이어가 주세요.
+                  </p>
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => setShowWarningBanner(false)}
+                aria-label="배너 닫기"
+                className="shrink-0 text-gray-900 transition-opacity hover:opacity-60"
+              >
+                <X size={24} aria-hidden="true" />
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* 문제 목록 */}
+        <div className="flex flex-col gap-30">
+          {questions.map((q) => (
+            <QuestionCard
+              key={q.question_id}
+              question={q}
+              answer={answers[q.question_id]}
+              onChange={(ans) => handleAnswerChange(q.question_id, ans)}
+            />
+          ))}
+        </div>
+
+        {/* 제출 버튼 */}
+        <div className="mt-30 flex justify-center">
+          <Button
+            variant="primary"
+            size="lg"
+            disabled={!allAnswered || isSubmitted}
+            loading={isSubmitting}
+            onClick={() => handleSubmit(answers, cheatingCount)}
+          >
+            제출하기
+          </Button>
+        </div>
+      </main>
+
+      {/* 부정행위 경고 모달 */}
+      <CheatingWarningModal
+        count={warningModalCount}
+        isOpen={warningModalCount > 0}
+        onConfirm={handleWarningConfirm}
+        onClose={() => setWarningModalCount(0)}
+      />
+
+      {/* 제출 완료 모달 */}
+      <ExamSubmitModal
+        isOpen={submitRedirectUrl !== null}
+        onConfirm={() => {
+          if (submitRedirectUrl) navigate(submitRedirectUrl, { replace: true })
+        }}
+      />
+    </div>
+  )
+}
+
 /**
- * @figma 쪽지시험_응시하기  https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-3969&m=dev
+ * @figma 쪽지시험_응시하기  https://www.figma.com/design/zTej1hAEgfChWzZhByThtt/%EC%9D%B5%EC%8A%A4%ED%84%B4%EC%8B%AD-%EC%AA%BD%EC%A7%80%EC%8B%9C%ED%97%98?node-id=1-710
  */
 export function QuizExamPage() {
-  return <div>쪽지시험 - 응시</div>
+  const { quizId } = useParams<{ quizId: string }>()
+  const deploymentId = Number(quizId)
+
+  if (!quizId || Number.isNaN(deploymentId)) {
+    return <Navigate to="/mypage/quiz" replace />
+  }
+
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center bg-white">
+          <Spinner />
+        </div>
+      }
+    >
+      <ExamContent deploymentId={deploymentId} />
+    </Suspense>
+  )
 }

--- a/src/providers/RouterProvider.tsx
+++ b/src/providers/RouterProvider.tsx
@@ -20,6 +20,9 @@ export function RouterProvider() {
         </Route>
       </Route>
 
+      {/* 시험 응시 — 헤더/푸터 없이 전체화면 전용 레이아웃 */}
+      <Route path="quiz/:quizId/exam" element={<QuizExamPage />} />
+
       {/* Header + Footer */}
       <Route element={<DefaultLayout />}>
         <Route index element={<HomePage />} />
@@ -32,7 +35,6 @@ export function RouterProvider() {
         </Route>
 
         <Route path="quiz/:quizId">
-          <Route path="exam" element={<QuizExamPage />} />
           <Route path="result" element={<QuizResultPage />} />
         </Route>
 


### PR DESCRIPTION
## 개요
쪽지시험 응시 페이지(`/quiz/:quizId/exam`)의 기본 구현입니다.

## 변경 사항

### 신규 훅
- `useExamTimer` — 남은 시간 카운트다운, 만료 시 콜백 실행 (이중 호출 방지)
- `useCheatingDetector` — fullscreenchange / visibilitychange / window.blur 기반 부정행위 감지, 1초 워밍업으로 페이지 진입 직후 오탐 방지

### 신규 컴포넌트
- `ExamHeader` — 시험 제목, 타이머(마지막 60초 빨간색), 부정행위 카운터
- `QuestionCard` — 문제 유형 분기 렌더링
- `OXQuestion`, `SingleChoiceQuestion`, `MultipleChoiceQuestion`, `ShortAnswerQuestion`, `FillBlankQuestion` — 문제 유형별 입력 UI
- `OrderingQuestion` — @dnd-kit/core 드래그앤드롭 순서 배열
- `CheatingWarningModal`, `ExamSubmitModal` — 부정행위 경고 및 제출 완료 모달

### 신규 Feature 모듈
- `features/exams/deployment-detail` — 응시 중인 시험 정보 조회
- `features/exams/submissions` — 시험 제출

### 페이지
- `QuizExamPage` — 위 훅/컴포넌트 조합, HTTP 상태별 에러 처리(ERROR_MAP), 전체화면 진입/해제

## 테스트 체크리스트
- [ ] 시험 응시 페이지 진입 및 문제 렌더링 확인
- [ ] 타이머 카운트다운 및 만료 자동 제출 확인
- [ ] 부정행위 감지 (탭 전환 / 전체화면 이탈) 확인
- [ ] 문제 유형별 입력 정상 동작 확인 (OX, 단일/복수선택, 단답, 빈칸, 순서)
- [ ] 제출 버튼 활성/비활성 조건 확인 (전체 답변 완료 시 활성화)

Closes #30