### PR TITLE
feat: 쪽지시험 응시 API 레이어 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.claude/settings.json
 .claude/settings.local.json
 
 # Playwright

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "test:visual:update-baseline": "node --experimental-strip-types e2e/scripts/update-figma-baselines.ts"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/react-query": "^5.95.2",
     "axios": "^1.13.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.3(@types/node@24.12.0)(jiti@2.6.1)(yaml@2.8.3))
@@ -186,6 +195,28 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@emnapi/core@1.9.1':
     resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
@@ -2223,6 +2254,31 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
   '@emnapi/core@1.9.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.0
@@ -4021,8 +4077,7 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   type-check@0.4.0:
     dependencies:

--- a/src/constants/httpStatus.ts
+++ b/src/constants/httpStatus.ts
@@ -7,5 +7,6 @@ export const HTTP_STATUS = {
   NOT_FOUND: 404,
   CONFLICT: 409,
   LOCKED: 423,
+  GONE: 410,
   INTERNAL_SERVER_ERROR: 500,
 } as const

--- a/src/features/exams/deployment-detail/handler.ts
+++ b/src/features/exams/deployment-detail/handler.ts
@@ -1,0 +1,92 @@
+import { http, HttpResponse } from 'msw'
+import type { DeploymentDetailResponse } from './types'
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
+
+const mockDetail: DeploymentDetailResponse = {
+  exam_id: 2,
+  exam_title: 'JavaScript 심화 쪽지시험',
+  duration_time: 30,
+  elapsed_time: 0,
+  cheating_count: 0,
+  questions: [
+    {
+      question_id: 1,
+      number: 1,
+      type: 'ox',
+      question: 'JavaScript에서 null == undefined는 true이다.',
+      point: 10,
+      prompt: null,
+      blank_count: null,
+      options: ['O', 'X'],
+      answer_input: null,
+    },
+    {
+      question_id: 2,
+      number: 2,
+      type: 'single_choice',
+      question: 'Array.prototype.map()의 반환값은 무엇인가?',
+      point: 10,
+      prompt: null,
+      blank_count: null,
+      options: ['새로운 배열', '원본 배열', 'undefined', 'null'],
+      answer_input: null,
+    },
+    {
+      question_id: 3,
+      number: 3,
+      type: 'multiple_choice',
+      question:
+        '다음 중 JavaScript의 원시 타입(Primitive type)에 해당하는 것을 모두 고르시오.',
+      point: 10,
+      prompt: null,
+      blank_count: null,
+      options: ['string', 'object', 'number', 'symbol', 'array'],
+      answer_input: null,
+    },
+    {
+      question_id: 4,
+      number: 4,
+      type: 'short_answer',
+      question: 'Promise의 세 가지 상태를 쉼표로 구분하여 적으시오.',
+      point: 10,
+      prompt: null,
+      blank_count: null,
+      options: null,
+      answer_input: null,
+    },
+    {
+      question_id: 5,
+      number: 5,
+      type: 'fill_blank',
+      question: '다음 문장의 빈칸을 채우시오.',
+      point: 10,
+      prompt:
+        '자바스크립트에서 [blank]는 값이 없음을 의미하고, [blank]는 존재하지 않음을 의미한다.',
+      blank_count: 2,
+      options: null,
+      answer_input: ['', ''],
+    },
+    {
+      question_id: 6,
+      number: 6,
+      type: 'ordering',
+      question: '다음 Promise 실행 순서를 올바르게 배열하시오.',
+      point: 10,
+      prompt: null,
+      blank_count: null,
+      options: ['콜백 등록', 'resolve 호출', 'Promise 생성', 'then 실행'],
+      answer_input: null,
+    },
+  ],
+}
+
+// GET /api/v1/exams/deployments/:deploymentId — 쪽지시험 문제 조회 API
+export const deploymentDetailHandlers = [
+  http.get(`${BASE_URL}/exams/deployments/:deploymentId`, ({ request }) => {
+    const url = new URL(request.url)
+    // check-code 서브패스는 별도 핸들러에서 처리
+    if (url.pathname.endsWith('check-code')) return
+    return HttpResponse.json<DeploymentDetailResponse>(mockDetail)
+  }),
+]

--- a/src/features/exams/deployment-detail/index.ts
+++ b/src/features/exams/deployment-detail/index.ts
@@ -1,0 +1,3 @@
+export type { QuestionType, Question, DeploymentDetailResponse } from './types'
+export { deploymentDetailQueries, useDeploymentDetail } from './queries'
+export { deploymentDetailHandlers } from './handler'

--- a/src/features/exams/deployment-detail/queries.ts
+++ b/src/features/exams/deployment-detail/queries.ts
@@ -1,0 +1,20 @@
+import { queryOptions, useSuspenseQuery } from '@tanstack/react-query'
+import api from '@/api/instance'
+import type { DeploymentDetailResponse } from './types'
+
+export const deploymentDetailQueries = {
+  detail: (deploymentId: number) =>
+    queryOptions({
+      queryKey: ['exams', 'deployments', deploymentId, 'detail'],
+      queryFn: async () => {
+        const { data } = await api.get<DeploymentDetailResponse>(
+          `exams/deployments/${deploymentId}`
+        )
+        return data
+      },
+    }),
+}
+
+export function useDeploymentDetail(deploymentId: number) {
+  return useSuspenseQuery(deploymentDetailQueries.detail(deploymentId))
+}

--- a/src/features/exams/deployment-detail/types.ts
+++ b/src/features/exams/deployment-detail/types.ts
@@ -1,0 +1,28 @@
+export type QuestionType =
+  | 'single_choice'
+  | 'multiple_choice'
+  | 'ox'
+  | 'short_answer'
+  | 'ordering'
+  | 'fill_blank'
+
+export interface Question {
+  question_id: number
+  number: number
+  type: QuestionType
+  question: string
+  point: number
+  prompt: string | null
+  blank_count: number | null
+  options: string[] | null
+  answer_input: string | string[] | null
+}
+
+export interface DeploymentDetailResponse {
+  exam_id: number
+  exam_title: string
+  duration_time: number
+  elapsed_time: number
+  cheating_count: number
+  questions: Question[]
+}

--- a/src/features/exams/submissions/handler.ts
+++ b/src/features/exams/submissions/handler.ts
@@ -1,0 +1,70 @@
+import { http, HttpResponse } from 'msw'
+import { HTTP_STATUS } from '@/constants/httpStatus'
+import type { SubmissionResponse } from './types'
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
+
+// POST /api/v1/exams/submissions — 답안 제출 API
+export const submissionsHandlers = [
+  http.post(`${BASE_URL}/exams/submissions`, async ({ request }) => {
+    const body = (await request.json()) as { deployment_id?: number }
+
+    // 400 — 유효하지 않은 시험 응시 세션
+    if (body.deployment_id === 997) {
+      return HttpResponse.json(
+        { error_detail: '유효하지 않은 시험 응시 세션입니다.' },
+        { status: HTTP_STATUS.BAD_REQUEST }
+      )
+    }
+
+    // 401 — 인증 실패
+    if (body.deployment_id === 996) {
+      return HttpResponse.json(
+        { error_detail: '자격 인증 데이터가 제공되지 않았습니다.' },
+        { status: HTTP_STATUS.UNAUTHORIZED }
+      )
+    }
+
+    // 403 — 권한 없음
+    if (body.deployment_id === 995) {
+      return HttpResponse.json(
+        { error_detail: '권한이 없습니다.' },
+        { status: HTTP_STATUS.FORBIDDEN }
+      )
+    }
+
+    // 404 — 시험 없음
+    if (body.deployment_id === 994) {
+      return HttpResponse.json(
+        { error_detail: '해당 시험 정보를 찾을 수 없습니다.' },
+        { status: HTTP_STATUS.NOT_FOUND }
+      )
+    }
+
+    // 409 — 중복 제출
+    if (body.deployment_id === 999) {
+      return HttpResponse.json(
+        { error_detail: '이미 제출된 시험입니다.' },
+        { status: HTTP_STATUS.CONFLICT }
+      )
+    }
+
+    // 410 — 시험 종료됨
+    if (body.deployment_id === 998) {
+      return HttpResponse.json(
+        { error_detail: '시험이 이미 종료되었습니다.' },
+        { status: HTTP_STATUS.GONE }
+      )
+    }
+
+    return HttpResponse.json<SubmissionResponse>(
+      {
+        submission_id: 1001,
+        score: 80,
+        correct_answer_count: 5,
+        redirect_url: `/quiz/${body.deployment_id ?? 2}/result`,
+      },
+      { status: HTTP_STATUS.CREATED }
+    )
+  }),
+]

--- a/src/features/exams/submissions/index.ts
+++ b/src/features/exams/submissions/index.ts
@@ -1,0 +1,7 @@
+export type {
+  SubmissionAnswer,
+  SubmissionRequest,
+  SubmissionResponse,
+} from './types'
+export { useSubmitExam } from './queries'
+export { submissionsHandlers } from './handler'

--- a/src/features/exams/submissions/queries.ts
+++ b/src/features/exams/submissions/queries.ts
@@ -1,0 +1,17 @@
+import { useMutation } from '@tanstack/react-query'
+import api from '@/api/instance'
+import type { SubmissionRequest, SubmissionResponse } from './types'
+
+export function useSubmitExam() {
+  return useMutation({
+    mutationFn: async (body: SubmissionRequest) => {
+      const { data } = await api.post<SubmissionResponse>(
+        'exams/submissions',
+        body
+      )
+      return data
+    },
+    // 재시도 시 409(중복 제출) 유발 방지
+    retry: 0,
+  })
+}

--- a/src/features/exams/submissions/types.ts
+++ b/src/features/exams/submissions/types.ts
@@ -1,0 +1,21 @@
+import type { QuestionType } from '../deployment-detail/types'
+
+export interface SubmissionAnswer {
+  question_id: number
+  type: QuestionType
+  submitted_answer: string | string[]
+}
+
+export interface SubmissionRequest {
+  deployment_id: number
+  started_at: string
+  cheating_count: number
+  answers: SubmissionAnswer[]
+}
+
+export interface SubmissionResponse {
+  submission_id: number
+  score: number
+  correct_answer_count: number
+  redirect_url: string
+}

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -6,6 +6,8 @@ import { meEnrolledCoursesHandlers } from '@/features/accounts/me-enrolled-cours
 import { checkCodeHandlers } from '@/features/exams/deployment-check-code'
 import { checkNicknameHandlers } from '@/features/accounts/check-nickname'
 import { meProfileImageHandlers } from '@/features/accounts/me-profile-image'
+import { deploymentDetailHandlers } from '@/features/exams/deployment-detail'
+import { submissionsHandlers } from '@/features/exams/submissions'
 
 export const handlers = [
   http.get('/api/health', () => {
@@ -15,7 +17,10 @@ export const handlers = [
   ...meEnrolledCoursesHandlers,
   ...deploymentsHandlers,
   ...loginHandlers,
+  // check-code는 deploymentDetail보다 먼저 등록해 패스 우선순위 확보
   ...checkCodeHandlers,
   ...checkNicknameHandlers,
   ...meProfileImageHandlers,
+  ...deploymentDetailHandlers,
+  ...submissionsHandlers,
 ]

--- a/src/providers/RouterProvider.tsx
+++ b/src/providers/RouterProvider.tsx
@@ -20,6 +20,9 @@ export function RouterProvider() {
         </Route>
       </Route>
 
+      {/* 시험 응시 — 헤더/푸터 없이 전체화면 전용 레이아웃 */}
+      <Route path="quiz/:quizId/exam" element={<QuizExamPage />} />
+
       {/* Header + Footer */}
       <Route element={<DefaultLayout />}>
         <Route index element={<HomePage />} />
@@ -32,7 +35,6 @@ export function RouterProvider() {
         </Route>
 
         <Route path="quiz/:quizId">
-          <Route path="exam" element={<QuizExamPage />} />
           <Route path="result" element={<QuizResultPage />} />
         </Route>
 


### PR DESCRIPTION
## 관련 이슈

- closes #32

## 작업 내용

- `features/exams/deployment-detail` feature 모듈 추가 (응시 중 시험 정보 조회)
- `features/exams/submissions` feature 모듈 추가 (시험 제출)
- `constants/httpStatus` 상수 추가
- MSW 핸들러 등록
- RouterProvider에 `/quiz/:quizId/exam` 경로 추가
- `@dnd-kit/core` 의존성 추가

## 변경 사항

- `src/features/exams/deployment-detail/` (types, queries, handler, index)
- `src/features/exams/submissions/` (types, queries, handler, index)
- `src/constants/httpStatus.ts`
- `src/mocks/handlers.ts`
- `src/providers/RouterProvider.tsx`
- `package.json`, `pnpm-lock.yaml`, `.gitignore`

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다