### PR TITLE
feat: 쪽지시험 문제 유형별 컴포넌트 및 훅 구현

### DIFF
--- a/src/components/quiz/FillBlankQuestion/FillBlankQuestion.tsx
+++ b/src/components/quiz/FillBlankQuestion/FillBlankQuestion.tsx
@@ -1,0 +1,62 @@
+interface FillBlankQuestionProps {
+  prompt: string
+  blankCount: number
+  answer: string[]
+  onChange: (answer: string[]) => void
+}
+
+export function FillBlankQuestion({
+  prompt,
+  answer,
+  onChange,
+}: FillBlankQuestionProps) {
+  const segments = prompt.split('[blank]')
+
+  const handleChange = (index: number, value: string) => {
+    const next = [...answer]
+    next[index] = value
+    onChange(next)
+  }
+
+  return (
+    <div className="flex max-w-[648px] flex-col gap-5">
+      {/* 지문: [blank] → (A) ________ 볼드 표시 */}
+      <div className="bg-bg-prompt rounded px-4 py-5">
+        <p className="text-base leading-normal tracking-[-0.03em] whitespace-pre-wrap text-gray-800">
+          {segments.map((segment, i) => (
+            <span key={i}>
+              {segment}
+              {i < segments.length - 1 && (
+                <strong className="font-bold">
+                  ({String.fromCharCode(65 + i)}) ________
+                </strong>
+              )}
+            </span>
+          ))}
+        </p>
+      </div>
+
+      {/* 빈칸 입력: A, B, C... 라벨 포함 */}
+      <div className="flex flex-col gap-3">
+        {answer.map((val, i) => (
+          <div
+            key={i}
+            className="bg-bg-muted flex h-12 max-w-[308px] items-center gap-2 rounded px-4 py-[10px]"
+          >
+            <span className="shrink-0 text-base leading-normal font-semibold tracking-[-0.03em] text-gray-800">
+              {String.fromCharCode(65 + i)}
+            </span>
+            <input
+              type="text"
+              value={val}
+              onChange={(e) => handleChange(i, e.target.value)}
+              placeholder="정답을 입력해 주세요."
+              aria-label={`빈칸 ${String.fromCharCode(65 + i)}`}
+              className="placeholder:text-gray-350 flex-1 bg-transparent text-base leading-normal tracking-[-0.03em] text-gray-800 outline-none"
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/quiz/FillBlankQuestion/index.ts
+++ b/src/components/quiz/FillBlankQuestion/index.ts
@@ -1,0 +1,1 @@
+export { FillBlankQuestion } from './FillBlankQuestion'

--- a/src/components/quiz/MultipleChoiceQuestion/MultipleChoiceQuestion.tsx
+++ b/src/components/quiz/MultipleChoiceQuestion/MultipleChoiceQuestion.tsx
@@ -1,0 +1,69 @@
+interface MultipleChoiceQuestionProps {
+  options: string[]
+  answer: string[]
+  onChange: (answer: string[]) => void
+}
+
+export function MultipleChoiceQuestion({
+  options,
+  answer,
+  onChange,
+}: MultipleChoiceQuestionProps) {
+  const toggle = (option: string) => {
+    if (answer.includes(option)) {
+      onChange(answer.filter((a) => a !== option))
+    } else {
+      onChange([...answer, option])
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {options.map((option, index) => {
+        const isSelected = answer.includes(option)
+        return (
+          <button
+            key={index}
+            type="button"
+            onClick={() => toggle(option)}
+            className="flex items-center gap-3 text-left"
+            aria-pressed={isSelected}
+          >
+            {/* 체크박스 */}
+            <span
+              className={[
+                'flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-sm border transition-colors',
+                isSelected
+                  ? 'border-primary bg-primary'
+                  : 'border-gray-350 bg-white',
+              ].join(' ')}
+            >
+              {isSelected && (
+                <svg
+                  width="10"
+                  height="8"
+                  viewBox="0 0 10 8"
+                  fill="none"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M1 4L3.5 6.5L9 1"
+                    stroke="white"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              )}
+            </span>
+
+            {/* 옵션 텍스트 */}
+            <span className="text-base leading-normal tracking-[-0.03em] text-gray-800">
+              {option}
+            </span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/quiz/MultipleChoiceQuestion/index.ts
+++ b/src/components/quiz/MultipleChoiceQuestion/index.ts
@@ -1,0 +1,1 @@
+export { MultipleChoiceQuestion } from './MultipleChoiceQuestion'

--- a/src/components/quiz/OXQuestion/OXQuestion.tsx
+++ b/src/components/quiz/OXQuestion/OXQuestion.tsx
@@ -1,0 +1,79 @@
+import { Circle, X, Check } from 'lucide-react'
+
+const OX_CONFIG = [
+  { value: 'O', label: '맞아요' },
+  { value: 'X', label: '아니에요' },
+] as const
+
+interface OXQuestionProps {
+  answer: string
+  onChange: (answer: string) => void
+}
+
+export function OXQuestion({ answer, onChange }: OXQuestionProps) {
+  return (
+    <div className="flex max-w-[308px] flex-col gap-3">
+      {OX_CONFIG.map(({ value, label }) => {
+        const isSelected = answer === value
+        const isO = value === 'O'
+
+        return (
+          <button
+            key={value}
+            type="button"
+            onClick={() => onChange(value)}
+            className={[
+              'flex h-12 items-center gap-2 rounded px-4 py-[10px] transition-colors duration-150',
+              isSelected
+                ? 'bg-primary-100 border-primary border'
+                : 'bg-bg-muted',
+            ].join(' ')}
+            aria-pressed={isSelected}
+          >
+            {/* O / X 아이콘 — currentColor로 부모 text 색상 참조 */}
+            <span
+              className={
+                isSelected
+                  ? isO
+                    ? 'text-success'
+                    : 'text-error'
+                  : 'text-gray-350'
+              }
+            >
+              {isO ? (
+                <Circle
+                  size={20}
+                  aria-hidden="true"
+                  stroke="currentColor"
+                  fill="none"
+                />
+              ) : (
+                <X size={20} aria-hidden="true" stroke="currentColor" />
+              )}
+            </span>
+
+            {/* 레이블 */}
+            <span
+              className={[
+                'flex-1 text-base leading-normal tracking-[-0.03em]',
+                isSelected ? 'text-primary' : 'text-gray-800',
+              ].join(' ')}
+            >
+              {label}
+            </span>
+
+            {/* 체크마크 */}
+            <span className={isSelected ? 'text-primary' : 'text-gray-350'}>
+              <Check
+                size={20}
+                aria-hidden="true"
+                stroke="currentColor"
+                className="transition-colors duration-150"
+              />
+            </span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/quiz/OXQuestion/index.ts
+++ b/src/components/quiz/OXQuestion/index.ts
@@ -1,0 +1,1 @@
+export { OXQuestion } from './OXQuestion'

--- a/src/components/quiz/OrderingQuestion/OrderingQuestion.tsx
+++ b/src/components/quiz/OrderingQuestion/OrderingQuestion.tsx
@@ -1,0 +1,256 @@
+import { useState } from 'react'
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+  useDraggable,
+  useDroppable,
+  type DragEndEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core'
+import { CSS } from '@dnd-kit/utilities'
+
+interface OrderingQuestionProps {
+  options: string[]
+  answer: string[]
+  onChange: (answer: string[]) => void
+}
+
+type DragData =
+  | { type: 'source'; item: string }
+  | { type: 'slot'; item: string; slotIndex: number }
+
+function SourceItem({
+  item,
+  label,
+  isPlaced,
+}: {
+  item: string
+  label: string
+  isPlaced: boolean
+}) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useDraggable({
+      id: `source::${item}`,
+      data: { type: 'source', item } satisfies DragData,
+      disabled: isPlaced,
+    })
+
+  const style = transform
+    ? { transform: CSS.Translate.toString(transform) }
+    : undefined
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={[
+        'flex items-center gap-2',
+        isPlaced
+          ? 'cursor-not-allowed opacity-40'
+          : 'cursor-grab active:cursor-grabbing',
+        isDragging ? 'opacity-0' : '',
+      ].join(' ')}
+      {...(!isPlaced ? { ...listeners, ...attributes } : {})}
+    >
+      <div className="bg-primary-100 flex h-8 w-8 shrink-0 items-center justify-center rounded">
+        <span
+          className={[
+            'text-base leading-normal font-semibold',
+            isPlaced ? 'text-gray-350' : 'text-primary',
+          ].join(' ')}
+        >
+          {label}
+        </span>
+      </div>
+      <span
+        className={[
+          'flex-1 text-base leading-normal tracking-[-0.03em]',
+          isPlaced ? 'text-gray-350' : 'text-gray-800',
+        ].join(' ')}
+      >
+        {item}
+      </span>
+    </div>
+  )
+}
+
+function SlotItem({
+  item,
+  slotIndex,
+  label,
+  onRemove,
+}: {
+  item: string
+  slotIndex: number
+  label: string
+  onRemove: () => void
+}) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useDraggable({
+      id: `slot::${slotIndex}`,
+      data: { type: 'slot', item, slotIndex } satisfies DragData,
+    })
+
+  const style = transform
+    ? { transform: CSS.Translate.toString(transform) }
+    : undefined
+
+  return (
+    <button
+      ref={setNodeRef}
+      style={style}
+      type="button"
+      onClick={onRemove}
+      aria-label={`슬롯 ${slotIndex + 1}: ${item} 제거`}
+      className={[
+        'bg-primary-100 flex h-[62px] w-[62px] cursor-grab items-center justify-center rounded transition-opacity active:cursor-grabbing',
+        isDragging ? 'opacity-0' : '',
+      ].join(' ')}
+      {...listeners}
+      {...attributes}
+    >
+      <span className="text-primary text-[18px] font-semibold">{label}</span>
+    </button>
+  )
+}
+
+function DropSlot({
+  slotIndex,
+  children,
+}: {
+  slotIndex: number
+  children?: React.ReactNode
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: `dropslot::${slotIndex}` })
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={[
+        'flex h-[62px] w-[62px] items-center justify-center rounded border-2 transition-colors duration-150',
+        isOver
+          ? 'border-primary bg-primary-100 border-dashed'
+          : 'bg-bg-muted border-transparent',
+      ].join(' ')}
+    >
+      {children}
+    </div>
+  )
+}
+
+export function OrderingQuestion({
+  options,
+  answer,
+  onChange,
+}: OrderingQuestionProps) {
+  const [activeData, setActiveData] = useState<{ label: string } | null>(null)
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 200, tolerance: 5 },
+    })
+  )
+
+  // 항상 options.length 크기의 배열 유지, 빈 슬롯은 ''
+  const slots: string[] = [
+    ...answer,
+    ...Array(Math.max(0, options.length - answer.length)).fill(''),
+  ].slice(0, options.length)
+
+  const placed = new Set(slots.filter(Boolean))
+
+  const getLetter = (item: string) => {
+    const idx = options.indexOf(item)
+    return idx >= 0 ? String.fromCharCode(65 + idx) : '?'
+  }
+
+  const handleDragStart = ({ active }: DragStartEvent) => {
+    const data = active.data.current as DragData
+    setActiveData({ label: getLetter(data.item) })
+  }
+
+  const handleDragEnd = ({ active, over }: DragEndEvent) => {
+    setActiveData(null)
+    if (!over) return
+
+    const overId = over.id as string
+    if (!overId.startsWith('dropslot::')) return
+
+    const targetSlot = parseInt(overId.replace('dropslot::', ''), 10)
+    const data = active.data.current as DragData
+    const next = [...slots]
+
+    if (data.type === 'source') {
+      if (placed.has(data.item)) return
+      next[targetSlot] = data.item
+    } else if (data.type === 'slot') {
+      const fromSlot = data.slotIndex
+      if (fromSlot === targetSlot) return // 두 슬롯 swap
+      ;[next[fromSlot], next[targetSlot]] = [next[targetSlot], next[fromSlot]]
+    }
+
+    onChange(next)
+  }
+
+  const handleRemoveSlot = (slotIndex: number) => {
+    const next = [...slots]
+    next[slotIndex] = ''
+    onChange(next)
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+    >
+      <div className="flex flex-col gap-5">
+        {/* 선택지 목록 */}
+        <div className="bg-bg-prompt max-w-[648px] rounded px-4 py-5">
+          <div className="flex flex-col gap-5">
+            {options.map((item, i) => (
+              <SourceItem
+                key={item}
+                item={item}
+                label={String.fromCharCode(65 + i)}
+                isPlaced={placed.has(item)}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* 순서 슬롯 */}
+        <div className="flex gap-[10px]">
+          {slots.map((placedItem, i) => (
+            <DropSlot key={i} slotIndex={i}>
+              {placedItem ? (
+                <SlotItem
+                  item={placedItem}
+                  slotIndex={i}
+                  label={getLetter(placedItem)}
+                  onRemove={() => handleRemoveSlot(i)}
+                />
+              ) : null}
+            </DropSlot>
+          ))}
+        </div>
+      </div>
+
+      {/* 드래그 중 미리보기 */}
+      <DragOverlay>
+        {activeData && (
+          <div className="bg-primary-100 flex h-[62px] w-[62px] cursor-grabbing items-center justify-center rounded opacity-90 shadow-lg">
+            <span className="text-primary text-[18px] font-semibold">
+              {activeData.label}
+            </span>
+          </div>
+        )}
+      </DragOverlay>
+    </DndContext>
+  )
+}

--- a/src/components/quiz/OrderingQuestion/index.ts
+++ b/src/components/quiz/OrderingQuestion/index.ts
@@ -1,0 +1,1 @@
+export { OrderingQuestion } from './OrderingQuestion'

--- a/src/components/quiz/ShortAnswerQuestion/ShortAnswerQuestion.tsx
+++ b/src/components/quiz/ShortAnswerQuestion/ShortAnswerQuestion.tsx
@@ -1,0 +1,21 @@
+interface ShortAnswerQuestionProps {
+  answer: string
+  onChange: (answer: string) => void
+}
+
+export function ShortAnswerQuestion({
+  answer,
+  onChange,
+}: ShortAnswerQuestionProps) {
+  return (
+    <div className="max-w-[648px]">
+      <input
+        type="text"
+        value={answer}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="20글자 이내로 입력해 주세요."
+        className="bg-bg-muted placeholder:text-gray-350 h-12 w-full rounded px-4 py-[10px] text-base leading-normal tracking-[-0.03em] text-gray-800 outline-none"
+      />
+    </div>
+  )
+}

--- a/src/components/quiz/ShortAnswerQuestion/index.ts
+++ b/src/components/quiz/ShortAnswerQuestion/index.ts
@@ -1,0 +1,1 @@
+export { ShortAnswerQuestion } from './ShortAnswerQuestion'

--- a/src/components/quiz/SingleChoiceQuestion/SingleChoiceQuestion.tsx
+++ b/src/components/quiz/SingleChoiceQuestion/SingleChoiceQuestion.tsx
@@ -1,0 +1,45 @@
+interface SingleChoiceQuestionProps {
+  options: string[]
+  answer: string
+  onChange: (answer: string) => void
+}
+
+export function SingleChoiceQuestion({
+  options,
+  answer,
+  onChange,
+}: SingleChoiceQuestionProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      {options.map((option, index) => {
+        const isSelected = answer === option
+        return (
+          <button
+            key={index}
+            type="button"
+            onClick={() => onChange(option)}
+            className="flex items-center gap-3 text-left"
+            aria-pressed={isSelected}
+          >
+            {/* 라디오 원 */}
+            <span
+              className={[
+                'flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full border-2 transition-colors',
+                isSelected
+                  ? 'border-primary bg-primary'
+                  : 'border-gray-350 bg-white',
+              ].join(' ')}
+            >
+              {isSelected && <span className="h-2 w-2 rounded-full bg-white" />}
+            </span>
+
+            {/* 옵션 텍스트 */}
+            <span className="text-base leading-normal tracking-[-0.03em] text-gray-800">
+              {option}
+            </span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/quiz/SingleChoiceQuestion/index.ts
+++ b/src/components/quiz/SingleChoiceQuestion/index.ts
@@ -1,0 +1,1 @@
+export { SingleChoiceQuestion } from './SingleChoiceQuestion'

--- a/src/hooks/useCheatingDetector.ts
+++ b/src/hooks/useCheatingDetector.ts
@@ -1,0 +1,93 @@
+import { useState, useEffect, useRef } from 'react'
+
+interface UseCheatingDetectorOptions {
+  initialCount: number
+  onDetect: (count: number) => void
+  enabled: boolean
+}
+
+interface UseCheatingDetectorResult {
+  cheatingCount: number
+}
+
+export function useCheatingDetector({
+  initialCount,
+  onDetect,
+  enabled,
+}: UseCheatingDetectorOptions): UseCheatingDetectorResult {
+  const [cheatingCount, setCheatingCount] = useState(initialCount)
+  const onDetectRef = useRef(onDetect)
+  // 두 이벤트가 동시에 발생할 때 이중 카운트 방지용 타임스탬프
+  const lastDetectedAt = useRef(0)
+  const prevCountRef = useRef(initialCount)
+
+  useEffect(() => {
+    onDetectRef.current = onDetect
+  })
+
+  // setState 업데이터 내부에서 콜백 호출 시 Strict Mode 더블 실행 문제 방지
+  useEffect(() => {
+    if (cheatingCount > prevCountRef.current) {
+      prevCountRef.current = cheatingCount
+      onDetectRef.current(cheatingCount)
+    }
+  }, [cheatingCount])
+
+  // 시험 중 탭 종료 / 새로고침 방지
+  useEffect(() => {
+    if (!enabled) return
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault()
+      e.returnValue = ''
+    }
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
+  }, [enabled])
+
+  useEffect(() => {
+    if (!enabled) return
+
+    // 페이지 진입 직후 네비게이션/포커스 전환으로 인한 오탐 방지
+    let active = false
+    const warmup = setTimeout(() => {
+      active = true
+    }, 1000)
+
+    const detect = () => {
+      if (!active) return
+      const now = Date.now()
+      // 300ms 내 중복 이벤트 무시 (fullscreenchange + visibilitychange 동시 발생 대응)
+      if (now - lastDetectedAt.current < 300) return
+      lastDetectedAt.current = now
+      setCheatingCount((prev) => prev + 1)
+    }
+
+    // 1. 전체화면 이탈 감지 (Escape, alt+tab 등)
+    const handleFullscreenChange = () => {
+      if (!document.fullscreenElement) detect()
+    }
+
+    // 2. 탭/창 전환 감지 — 전체화면 미지원 브라우저 fallback 및 보조 감지
+    const handleVisibilityChange = () => {
+      if (document.hidden) detect()
+    }
+
+    // 3. 듀얼모니터 등 다른 앱/창 포커스 감지 — visibilitychange가 발생하지 않는 경우 보완
+    const handleWindowBlur = () => {
+      if (!document.hasFocus()) detect()
+    }
+
+    document.addEventListener('fullscreenchange', handleFullscreenChange)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    window.addEventListener('blur', handleWindowBlur)
+
+    return () => {
+      clearTimeout(warmup)
+      document.removeEventListener('fullscreenchange', handleFullscreenChange)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+      window.removeEventListener('blur', handleWindowBlur)
+    }
+  }, [enabled])
+
+  return { cheatingCount }
+}

--- a/src/hooks/useExamTimer.ts
+++ b/src/hooks/useExamTimer.ts
@@ -1,0 +1,66 @@
+import { useState, useEffect, useRef } from 'react'
+
+interface UseExamTimerOptions {
+  initialSeconds: number
+  onExpire: () => void
+}
+
+interface UseExamTimerResult {
+  remainingSeconds: number
+  formattedTime: string
+}
+
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60)
+  const s = seconds % 60
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
+}
+
+export function useExamTimer({
+  initialSeconds,
+  onExpire,
+}: UseExamTimerOptions): UseExamTimerResult {
+  const [remainingSeconds, setRemainingSeconds] = useState(
+    Math.max(0, initialSeconds)
+  )
+  const onExpireRef = useRef(onExpire)
+  // Strict Mode 더블 마운트 또는 cleanup 후 재큐잉으로 onExpire 중복 호출 방지
+  const expiredRef = useRef(false)
+  const expireTimeoutRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    onExpireRef.current = onExpire
+  })
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setRemainingSeconds((prev) => {
+        const next = prev - 1
+        if (next <= 0) {
+          clearInterval(timer)
+          if (!expiredRef.current) {
+            expiredRef.current = true
+            expireTimeoutRef.current = window.setTimeout(
+              () => onExpireRef.current(),
+              0
+            )
+          }
+          return 0
+        }
+        return next
+      })
+    }, 1000)
+
+    return () => {
+      clearInterval(timer)
+      if (expireTimeoutRef.current !== null) {
+        clearTimeout(expireTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  return {
+    remainingSeconds,
+    formattedTime: formatTime(remainingSeconds),
+  }
+}


### PR DESCRIPTION
## 관련 이슈

- closes #33

## 작업 내용

- `useExamTimer` 훅 추가 (남은 시간 카운트다운, 만료 콜백)
- `useCheatingDetector` 훅 추가 (fullscreenchange / visibilitychange / blur 감지)
- 문제 유형별 컴포넌트 추가 (OX, 단일선택, 복수선택, 단답, 빈칸, 순서배열)

## 변경 사항

- `src/hooks/useExamTimer.ts`
- `src/hooks/useCheatingDetector.ts`
- `src/components/quiz/OXQuestion/`
- `src/components/quiz/SingleChoiceQuestion/`
- `src/components/quiz/MultipleChoiceQuestion/`
- `src/components/quiz/ShortAnswerQuestion/`
- `src/components/quiz/FillBlankQuestion/`
- `src/components/quiz/OrderingQuestion/`

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다