### PR TITLE
feat: 쪽지시험 응시 페이지 조립

### DIFF
--- a/src/assets/cheating/exit.svg
+++ b/src/assets/cheating/exit.svg
@@ -1,0 +1,17 @@
+<svg width="72" height="106" viewBox="0 0 72 106" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1_4534)">
+<path d="M70.7498 0.75H20.5898V86.46H70.7498V0.75Z" fill="#EC0037" stroke="#121212" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M47.3496 86.4609V88.7209C47.3496 94.2809 43.6496 98.7909 39.0996 98.7909V104.451" stroke="#121212" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14.0801 79.3619L28.2001 65.2419C30.2101 63.2319 33.4801 63.2319 35.4901 65.2419C37.5001 67.2519 37.5001 70.5219 35.4901 72.5319L23.1601 84.8619C25.6501 85.5519 27.5401 88.8019 27.5401 92.6919C27.5401 93.4619 27.4701 94.2019 27.3301 94.9019" fill="white"/>
+<path d="M14.0801 79.3619L28.2001 65.2419C30.2101 63.2319 33.4801 63.2319 35.4901 65.2419C37.5001 67.2519 37.5001 70.5219 35.4901 72.5319L23.1601 84.8619C25.6501 85.5519 27.5401 88.8019 27.5401 92.6919C27.5401 93.4619 27.4701 94.2019 27.3301 94.9019" stroke="#121212" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8.08984 104.441V80.5308C8.08984 75.6708 9.97984 70.9808 13.3898 67.5208C15.6998 65.1808 18.3798 62.7508 20.5898 61.5508" stroke="#121212" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M0.75 104.441H47.11" stroke="#121212" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M45.6699 33.8594V46.4194" stroke="#121212" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M45.75 51.5C46.3023 51.5 46.75 51.0523 46.75 50.5C46.75 49.9477 46.3023 49.5 45.75 49.5C45.1977 49.5 44.75 49.9477 44.75 50.5C44.75 51.0523 45.1977 51.5 45.75 51.5Z" fill="#121212"/>
+</g>
+<defs>
+<clipPath id="clip0_1_4534">
+<rect width="71.5" height="105.19" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/assets/cheating/warning.svg
+++ b/src/assets/cheating/warning.svg
@@ -1,0 +1,17 @@
+<svg width="72" height="106" viewBox="0 0 72 106" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1_4506)">
+<path d="M70.7498 0.75H20.5898V86.46H70.7498V0.75Z" fill="#FFAE00" stroke="#121212" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M47.3496 86.4609V88.7209C47.3496 94.2809 43.6496 98.7909 39.0996 98.7909V104.451" stroke="#121212" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14.0801 79.3619L28.2001 65.2419C30.2101 63.2319 33.4801 63.2319 35.4901 65.2419C37.5001 67.2519 37.5001 70.5219 35.4901 72.5319L23.1601 84.8619C25.6501 85.5519 27.5401 88.8019 27.5401 92.6919C27.5401 93.4619 27.4701 94.2019 27.3301 94.9019" fill="white"/>
+<path d="M14.0801 79.3619L28.2001 65.2419C30.2101 63.2319 33.4801 63.2319 35.4901 65.2419C37.5001 67.2519 37.5001 70.5219 35.4901 72.5319L23.1601 84.8619C25.6501 85.5519 27.5401 88.8019 27.5401 92.6919C27.5401 93.4619 27.4701 94.2019 27.3301 94.9019" stroke="#121212" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8.08984 104.441V80.5308C8.08984 75.6708 9.97984 70.9808 13.3898 67.5208C15.6998 65.1808 18.3798 62.7508 20.5898 61.5508" stroke="#121212" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M0.75 104.441H47.11" stroke="#121212" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M45.6699 33.8594V46.4194" stroke="#121212" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M45.75 51.5C46.3023 51.5 46.75 51.0523 46.75 50.5C46.75 49.9477 46.3023 49.5 45.75 49.5C45.1977 49.5 44.75 49.9477 44.75 50.5C44.75 51.0523 45.1977 51.5 45.75 51.5Z" fill="#121212"/>
+</g>
+<defs>
+<clipPath id="clip0_1_4506">
+<rect width="71.5" height="105.19" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/components/quiz/CheatingWarningModal/CheatingWarningModal.tsx
+++ b/src/components/quiz/CheatingWarningModal/CheatingWarningModal.tsx
@@ -1,0 +1,100 @@
+import { Modal } from '@/components/common/Modal'
+import { Button } from '@/components/common/Button'
+import warningSvg from '@/assets/cheating/warning.svg'
+import exitSvg from '@/assets/cheating/exit.svg'
+
+interface CheatingWarningModalProps {
+  count: number
+  isOpen: boolean
+  onConfirm: () => void
+  onClose: () => void
+}
+
+const MESSAGES: Record<1 | 2 | 3, { lines: string[]; button: string }> = {
+  1: {
+    lines: [
+      '다른 화면으로 이동했어요.',
+      '부정행위로 간주되며, 누적 시 시험이 종료될 수 있어요.',
+    ],
+    button: '확인',
+  },
+  2: {
+    lines: [
+      '한 번 더 화면을 이탈했어요.',
+      '3회 이상 감지되면 시험이 자동 종료됩니다.',
+    ],
+    button: '확인',
+  },
+  3: {
+    lines: [
+      '세 번째 이탈이 감지됐어요.',
+      '부정행위로 처리되어 시험이 종료됩니다.',
+    ],
+    button: '시험종료',
+  },
+}
+
+function ModalIcon({ count }: { count: 1 | 2 | 3 }) {
+  if (count >= 3)
+    return (
+      <img
+        src={exitSvg}
+        alt=""
+        aria-hidden="true"
+        className="h-[106px] w-[72px]"
+      />
+    )
+  return (
+    <img
+      src={warningSvg}
+      alt=""
+      aria-hidden="true"
+      className="h-[106px] w-[72px]"
+    />
+  )
+}
+
+function ModalTitle({ count }: { count: 1 | 2 | 3 }) {
+  const accentColor = count >= 3 ? 'text-error' : 'text-warning'
+  return (
+    <h3 className="text-text-heading text-xl leading-normal font-semibold tracking-[-0.03em]">
+      부정행위 <span className={accentColor}>{count}회</span> 감지
+    </h3>
+  )
+}
+
+export function CheatingWarningModal({
+  count,
+  isOpen,
+  onConfirm,
+  onClose,
+}: CheatingWarningModalProps) {
+  const safeCount = Math.max(1, Math.min(count, 3)) as 1 | 2 | 3
+  const msg = MESSAGES[safeCount]
+  const final = count >= 3
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={final ? onConfirm : onClose}
+      maxWidth="max-w-md"
+    >
+      <div className="flex flex-col items-center gap-6 py-4 text-center">
+        <ModalIcon count={safeCount} />
+
+        <div className="flex flex-col gap-2">
+          <ModalTitle count={safeCount} />
+          <div className="text-text-body flex flex-col text-base leading-normal">
+            {msg.lines.map((line, i) => (
+              <p key={i}>{line}</p>
+            ))}
+          </div>
+        </div>
+
+        <Button variant="primary" size="lg" fullWidth onClick={onConfirm}>
+          {msg.button}
+        </Button>
+      </div>
+    </Modal>
+  )
+}

--- a/src/components/quiz/CheatingWarningModal/index.ts
+++ b/src/components/quiz/CheatingWarningModal/index.ts
@@ -1,0 +1,1 @@
+export { CheatingWarningModal } from './CheatingWarningModal'

--- a/src/components/quiz/ExamHeader/ExamHeader.tsx
+++ b/src/components/quiz/ExamHeader/ExamHeader.tsx
@@ -1,0 +1,108 @@
+import { ArrowLeft } from 'lucide-react'
+
+interface ExamHeaderProps {
+  examTitle: string
+  formattedTime: string
+  remainingSeconds: number
+  cheatingCount: number
+  onBack: () => void
+}
+
+export function ExamHeader({
+  examTitle,
+  formattedTime,
+  remainingSeconds,
+  cheatingCount,
+  onBack,
+}: ExamHeaderProps) {
+  const isUrgent = remainingSeconds > 0 && remainingSeconds <= 60
+  const [minutes, seconds] = formattedTime.split(':')
+
+  const timerColor = isUrgent ? 'text-error' : 'text-primary'
+
+  return (
+    <header className="border-gray-350 fixed top-0 right-0 left-0 z-40 border-b bg-gray-100">
+      {/* 스크린리더용 부정행위 카운트 실시간 알림 */}
+      <span className="sr-only" role="status" aria-live="polite">
+        {cheatingCount > 0 ? `부정행위 ${cheatingCount}회 감지됨` : ''}
+      </span>
+
+      <div className="max-w-container mx-auto flex h-[128px] items-center justify-between px-6">
+        {/* 좌측: 뒤로가기 + 시험 제목 + 부제 */}
+        <div className="flex items-start gap-3">
+          <button
+            type="button"
+            onClick={onBack}
+            aria-label="시험 목록으로 돌아가기"
+            className="mt-1 shrink-0 text-gray-900"
+          >
+            <ArrowLeft size={24} aria-hidden="true" />
+          </button>
+          <div className="flex flex-col gap-5 py-1">
+            <span className="text-xl leading-normal font-semibold tracking-[-0.03em] text-gray-900">
+              {examTitle}
+            </span>
+            <span className="text-base leading-normal font-normal tracking-[-0.03em] text-gray-600">
+              집중해서 천천히, 끝까지 응시해 주세요. 응원할게요 💪
+            </span>
+          </div>
+        </div>
+
+        {/* 우측: 타이머 + 부정행위 */}
+        <div className="flex items-center gap-6">
+          {/* 타이머 pill */}
+          <div className="border-disable flex items-center gap-[2px] rounded-full border bg-white px-4 py-4">
+            <span
+              className={`text-lg leading-normal font-semibold tracking-[-0.03em] ${timerColor}`}
+            >
+              {minutes}
+            </span>
+            <span className={`text-lg font-semibold ${timerColor}`}>:</span>
+            <span
+              className={`text-lg leading-normal font-semibold tracking-[-0.03em] ${timerColor}`}
+            >
+              {seconds}
+            </span>
+            <span
+              className={`ml-2 text-lg leading-normal font-semibold tracking-[-0.03em] ${timerColor}`}
+            >
+              뒤에 끝나요
+            </span>
+          </div>
+
+          {/* 부정행위 pill */}
+          <div
+            className="border-disable flex items-center gap-[14px] rounded-full border bg-white px-4 py-4"
+            aria-label={`부정행위 ${cheatingCount}회 감지됨`}
+          >
+            <span
+              className="text-lg leading-normal font-semibold tracking-[-0.03em] text-gray-700"
+              aria-hidden="true"
+            >
+              부정행위
+            </span>
+            <div className="flex gap-2" aria-hidden="true">
+              {[1, 2, 3].map((n) => {
+                const filled = cheatingCount >= n
+                const isDanger = n === 3 && filled
+                return (
+                  <span
+                    key={n}
+                    className={[
+                      'inline-block h-[26.667px] w-5 rounded-sm border-[1.5px]',
+                      isDanger
+                        ? 'border-error bg-error'
+                        : filled
+                          ? 'border-warning bg-warning'
+                          : 'border-gray-350 bg-gray-100',
+                    ].join(' ')}
+                  />
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/src/components/quiz/ExamHeader/index.ts
+++ b/src/components/quiz/ExamHeader/index.ts
@@ -1,0 +1,1 @@
+export { ExamHeader } from './ExamHeader'

--- a/src/components/quiz/ExamSubmitModal/ExamSubmitModal.tsx
+++ b/src/components/quiz/ExamSubmitModal/ExamSubmitModal.tsx
@@ -1,0 +1,37 @@
+import { Check } from 'lucide-react'
+import { Modal } from '@/components/common/Modal'
+import { Button } from '@/components/common/Button'
+
+interface ExamSubmitModalProps {
+  isOpen: boolean
+  onConfirm: () => void
+}
+
+export function ExamSubmitModal({ isOpen, onConfirm }: ExamSubmitModalProps) {
+  return (
+    <Modal isOpen={isOpen} onClose={onConfirm} maxWidth="max-w-md">
+      <div className="flex flex-col items-center gap-6 py-4 text-center">
+        {/* 아이콘 */}
+        <div className="bg-success flex h-20 w-20 items-center justify-center rounded-full">
+          <Check size={40} stroke="white" aria-hidden="true" />
+        </div>
+
+        {/* 타이틀 */}
+        <div className="flex flex-col gap-3">
+          <h3 className="text-text-heading text-xl leading-normal font-semibold tracking-[-0.03em]">
+            시험 제출이 <span className="text-success">완료</span> 되었습니다
+          </h3>
+          <div className="text-text-body flex flex-col text-base leading-normal">
+            <p>시험이 종료 되었습니다</p>
+            <p>시험 제출이 완료 되었습니다!</p>
+            <p>정답 확인 페이지로 넘어갑니다.</p>
+          </div>
+        </div>
+
+        <Button variant="primary" size="lg" fullWidth onClick={onConfirm}>
+          확인
+        </Button>
+      </div>
+    </Modal>
+  )
+}

--- a/src/components/quiz/ExamSubmitModal/index.ts
+++ b/src/components/quiz/ExamSubmitModal/index.ts
@@ -1,0 +1,1 @@
+export { ExamSubmitModal } from './ExamSubmitModal'

--- a/src/components/quiz/QuestionCard/QuestionCard.tsx
+++ b/src/components/quiz/QuestionCard/QuestionCard.tsx
@@ -1,0 +1,111 @@
+import { OXQuestion } from '@/components/quiz/OXQuestion'
+import { SingleChoiceQuestion } from '@/components/quiz/SingleChoiceQuestion'
+import { MultipleChoiceQuestion } from '@/components/quiz/MultipleChoiceQuestion'
+import { ShortAnswerQuestion } from '@/components/quiz/ShortAnswerQuestion'
+import { OrderingQuestion } from '@/components/quiz/OrderingQuestion'
+import { FillBlankQuestion } from '@/components/quiz/FillBlankQuestion'
+import type { Question } from '@/features/exams/deployment-detail'
+
+const TYPE_LABELS: Record<Question['type'], string> = {
+  ox: 'OX선택',
+  single_choice: '단일선택',
+  multiple_choice: '다중선택',
+  short_answer: '단답형',
+  ordering: '순서배열',
+  fill_blank: '빈칸식',
+}
+
+interface QuestionCardProps {
+  question: Question
+  answer: string | string[]
+  onChange: (answer: string | string[]) => void
+}
+
+export function QuestionCard({
+  question,
+  answer,
+  onChange,
+}: QuestionCardProps) {
+  const renderInput = () => {
+    switch (question.type) {
+      case 'ox':
+      case 'single_choice':
+      case 'short_answer': {
+        if (typeof answer !== 'string') return null
+        if (question.type === 'ox') {
+          return <OXQuestion answer={answer} onChange={onChange} />
+        }
+        if (question.type === 'single_choice') {
+          return (
+            <SingleChoiceQuestion
+              options={question.options ?? []}
+              answer={answer}
+              onChange={onChange}
+            />
+          )
+        }
+        return <ShortAnswerQuestion answer={answer} onChange={onChange} />
+      }
+      case 'multiple_choice':
+      case 'ordering':
+      case 'fill_blank': {
+        if (!Array.isArray(answer)) return null
+        if (question.type === 'multiple_choice') {
+          return (
+            <MultipleChoiceQuestion
+              options={question.options ?? []}
+              answer={answer}
+              onChange={onChange}
+            />
+          )
+        }
+        if (question.type === 'ordering') {
+          return (
+            <OrderingQuestion
+              options={question.options ?? []}
+              answer={answer}
+              onChange={onChange}
+            />
+          )
+        }
+        return (
+          <FillBlankQuestion
+            prompt={question.prompt ?? ''}
+            blankCount={question.blank_count ?? 0}
+            answer={answer}
+            onChange={onChange}
+          />
+        )
+      }
+      default:
+        return null
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      {/* 헤더: 번호 + 문제 텍스트 + 배점/유형 뱃지 */}
+      <div className="flex items-start gap-4">
+        <div className="flex flex-1 items-start py-1">
+          <span className="w-8 shrink-0 text-xl leading-normal font-bold tracking-[-0.03em] text-gray-900">
+            {question.number}.
+          </span>
+          <p className="text-xl leading-normal font-bold tracking-[-0.03em] text-gray-900">
+            {question.question}
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <span className="bg-disable rounded-sm px-3 py-2 text-xs leading-normal tracking-[-0.03em] whitespace-nowrap text-gray-900">
+            {question.point}점
+          </span>
+          <span className="bg-disable rounded-sm px-3 py-2 text-xs leading-normal tracking-[-0.03em] whitespace-nowrap text-gray-900">
+            {TYPE_LABELS[question.type]}
+          </span>
+        </div>
+      </div>
+
+      {/* 답안 입력 — 번호(32px) 너비만큼 들여쓰기 */}
+      <div className="pl-8">{renderInput()}</div>
+    </div>
+  )
+}

--- a/src/components/quiz/QuestionCard/index.ts
+++ b/src/components/quiz/QuestionCard/index.ts
@@ -1,0 +1,1 @@
+export { QuestionCard } from './QuestionCard'

--- a/src/pages/quiz/QuizExamPage.tsx
+++ b/src/pages/quiz/QuizExamPage.tsx
@@ -1,6 +1,349 @@
+import { Suspense, useState, useRef, useCallback, useEffect } from 'react'
+import { X } from 'lucide-react'
+import { useParams, useNavigate, Navigate } from 'react-router'
+import axios from 'axios'
+import { Button } from '@/components/common/Button'
+import { Spinner } from '@/components/common/Spinner'
+import { ExamHeader } from '@/components/quiz/ExamHeader'
+import { CheatingWarningModal } from '@/components/quiz/CheatingWarningModal'
+import { ExamSubmitModal } from '@/components/quiz/ExamSubmitModal'
+import { QuestionCard } from '@/components/quiz/QuestionCard'
+import { useDeploymentDetail } from '@/features/exams/deployment-detail'
+import { useSubmitExam } from '@/features/exams/submissions'
+import { useExamTimer } from '@/hooks/useExamTimer'
+import { useCheatingDetector } from '@/hooks/useCheatingDetector'
+import { useToastStore } from '@/stores/toastStore'
+import { HTTP_STATUS } from '@/constants/httpStatus'
+import type { Question } from '@/features/exams/deployment-detail'
+import type { SubmissionAnswer } from '@/features/exams/submissions'
+
+interface ApiErrorBody {
+  error_detail?: string
+}
+
+const ERROR_MAP: Record<number, { fallback: string; redirect?: string }> = {
+  [HTTP_STATUS.BAD_REQUEST]: {
+    fallback: '유효하지 않은 시험 응시 세션입니다.',
+    redirect: '/mypage/quiz',
+  },
+  [HTTP_STATUS.UNAUTHORIZED]: {
+    fallback: '로그인이 필요합니다.',
+    redirect: '/auth/login',
+  },
+  [HTTP_STATUS.FORBIDDEN]: {
+    fallback: '권한이 없습니다.',
+    redirect: '/mypage/quiz',
+  },
+  [HTTP_STATUS.NOT_FOUND]: {
+    fallback: '해당 시험 정보를 찾을 수 없습니다.',
+    redirect: '/mypage/quiz',
+  },
+  [HTTP_STATUS.CONFLICT]: { fallback: '이미 제출된 시험입니다.' },
+  [HTTP_STATUS.GONE]: {
+    fallback: '시험이 종료되었습니다.',
+    redirect: '/mypage/quiz',
+  },
+}
+
+function initAnswers(questions: Question[]): Record<number, string | string[]> {
+  const map: Record<number, string | string[]> = {}
+  for (const q of questions) {
+    if (
+      q.type === 'single_choice' ||
+      q.type === 'ox' ||
+      q.type === 'short_answer'
+    ) {
+      map[q.question_id] =
+        typeof q.answer_input === 'string' ? q.answer_input : ''
+    } else if (q.type === 'multiple_choice') {
+      map[q.question_id] = Array.isArray(q.answer_input) ? q.answer_input : []
+    } else if (q.type === 'ordering') {
+      map[q.question_id] = Array.isArray(q.answer_input) ? q.answer_input : []
+    } else if (q.type === 'fill_blank') {
+      map[q.question_id] = Array.isArray(q.answer_input)
+        ? q.answer_input
+        : Array<string>(q.blank_count ?? 0).fill('')
+    }
+  }
+  return map
+}
+
+function isAnswered(q: Question, answer: string | string[]): boolean {
+  if (q.type === 'ordering') {
+    const ans = answer as string[]
+    return ans.length === (q.options?.length ?? 0) && ans.every((a) => a !== '')
+  }
+  if (Array.isArray(answer))
+    return answer.length > 0 && answer.every((a) => a !== '')
+  return (answer as string).trim() !== ''
+}
+
+interface ExamContentProps {
+  deploymentId: number
+}
+
+function AlertCircleIcon() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+      className="text-error shrink-0"
+    >
+      <circle cx="12" cy="12" r="10" fill="currentColor" />
+      <path d="M12 7v6" stroke="white" strokeWidth="2" strokeLinecap="round" />
+      <circle cx="12" cy="16.5" r="1" fill="white" />
+    </svg>
+  )
+}
+
+function ExamContent({ deploymentId }: ExamContentProps) {
+  const navigate = useNavigate()
+  const showToast = useToastStore((s) => s.show)
+
+  const { data } = useDeploymentDetail(deploymentId)
+  const { mutate: submitExam, isPending: isSubmitting } = useSubmitExam()
+
+  const { exam_title, duration_time, elapsed_time, cheating_count, questions } =
+    data
+
+  const [answers, setAnswers] = useState<Record<number, string | string[]>>(
+    () => initAnswers(questions)
+  )
+  const [showWarningBanner, setShowWarningBanner] = useState(true)
+  const [warningModalCount, setWarningModalCount] = useState(0)
+  const [isSubmitted, setIsSubmitted] = useState(false)
+  const [submitRedirectUrl, setSubmitRedirectUrl] = useState<string | null>(
+    null
+  )
+  // 사용자 제스처(버튼 클릭) 이후 fullscreen 진입 및 시험 시작 상태
+  const startedAt = useRef(new Date().toISOString().slice(0, 19))
+
+  useEffect(() => {
+    document.documentElement.requestFullscreen().catch(() => {})
+    return () => {
+      if (document.fullscreenElement) {
+        document.exitFullscreen().catch(() => {})
+      }
+    }
+  }, [])
+
+  const allAnswered = questions.every((q) =>
+    isAnswered(q, answers[q.question_id])
+  )
+
+  const buildSubmissionAnswers = useCallback(
+    (currentAnswers: Record<number, string | string[]>): SubmissionAnswer[] =>
+      questions.map((q) => ({
+        question_id: q.question_id,
+        type: q.type,
+        submitted_answer: currentAnswers[q.question_id] ?? '',
+      })),
+    [questions]
+  )
+
+  const handleSubmit = useCallback(
+    (
+      currentAnswers: Record<number, string | string[]>,
+      currentCheating: number,
+      onSuccess?: (redirectUrl: string) => void
+    ) => {
+      if (isSubmitted) return
+      setIsSubmitted(true)
+
+      submitExam(
+        {
+          deployment_id: deploymentId,
+          started_at: startedAt.current,
+          cheating_count: currentCheating,
+          answers: buildSubmissionAnswers(currentAnswers),
+        },
+        {
+          onSuccess: (res) => {
+            if (onSuccess) {
+              onSuccess(res.redirect_url)
+            } else {
+              setSubmitRedirectUrl(res.redirect_url)
+            }
+          },
+          onError: (error) => {
+            setIsSubmitted(false)
+            if (!axios.isAxiosError(error)) return
+
+            const status = error.response?.status
+            const detail = (error.response?.data as ApiErrorBody | undefined)
+              ?.error_detail
+            const config = status ? ERROR_MAP[status] : undefined
+            showToast(
+              detail ?? config?.fallback ?? '서버 오류가 발생했습니다.',
+              'error'
+            )
+            if (config?.redirect) navigate(config.redirect)
+          },
+        }
+      )
+    },
+    [
+      isSubmitted,
+      deploymentId,
+      navigate,
+      showToast,
+      submitExam,
+      buildSubmissionAnswers,
+    ]
+  )
+
+  const { cheatingCount } = useCheatingDetector({
+    initialCount: cheating_count,
+    onDetect: (count) => setWarningModalCount(count),
+    enabled: !isSubmitted,
+  })
+
+  const handleTimerExpire = useCallback(() => {
+    handleSubmit(answers, cheatingCount, (url) =>
+      navigate(url, { replace: true })
+    )
+  }, [answers, cheatingCount, handleSubmit, navigate])
+
+  const { formattedTime, remainingSeconds } = useExamTimer({
+    initialSeconds: duration_time * 60 - elapsed_time,
+    onExpire: handleTimerExpire,
+  })
+
+  const handleWarningConfirm = useCallback(() => {
+    setWarningModalCount(0)
+    if (cheatingCount >= 3) {
+      handleSubmit(answers, cheatingCount, (url) =>
+        navigate(url, { replace: true })
+      )
+    } else {
+      document.documentElement.requestFullscreen().catch(() => {})
+    }
+  }, [answers, cheatingCount, handleSubmit, navigate])
+
+  const handleAnswerChange = useCallback(
+    (questionId: number, answer: string | string[]) => {
+      setAnswers((prev) => ({ ...prev, [questionId]: answer }))
+    },
+    []
+  )
+
+  const handleBack = useCallback(() => {
+    if (document.fullscreenElement) {
+      document.exitFullscreen().catch(() => {})
+    }
+    navigate('/mypage/quiz')
+  }, [navigate])
+
+  return (
+    <div className="min-h-screen bg-white">
+      <ExamHeader
+        examTitle={exam_title}
+        formattedTime={formattedTime}
+        remainingSeconds={remainingSeconds}
+        cheatingCount={cheatingCount}
+        onBack={handleBack}
+      />
+
+      {/* 헤더 높이(128px) + 여백 보정 */}
+      <main className="max-w-container mx-auto px-6 pt-[160px] pb-24">
+        {/* 부정행위 안내 배너 */}
+        {showWarningBanner && (
+          <div className="bg-primary-100 mb-6 rounded-lg px-6 py-5">
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex items-start gap-3">
+                <span className="mt-0.5 shrink-0">
+                  <AlertCircleIcon />
+                </span>
+                <div className="flex flex-col gap-5">
+                  <p className="text-lg leading-normal font-semibold tracking-[-0.03em] text-gray-900">
+                    시험에만 집중해 주세요
+                  </p>
+                  <p className="text-base leading-normal tracking-[-0.03em] text-gray-900">
+                    탭이나 창을 이동하면 부정행위로 처리돼 시험이 중단될 수
+                    있어요. 안정적인 환경에서 시험을 이어가 주세요.
+                  </p>
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => setShowWarningBanner(false)}
+                aria-label="배너 닫기"
+                className="shrink-0 text-gray-900 transition-opacity hover:opacity-60"
+              >
+                <X size={24} aria-hidden="true" />
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* 문제 목록 */}
+        <div className="flex flex-col gap-30">
+          {questions.map((q) => (
+            <QuestionCard
+              key={q.question_id}
+              question={q}
+              answer={answers[q.question_id]}
+              onChange={(ans) => handleAnswerChange(q.question_id, ans)}
+            />
+          ))}
+        </div>
+
+        {/* 제출 버튼 */}
+        <div className="mt-30 flex justify-center">
+          <Button
+            variant="primary"
+            size="lg"
+            disabled={!allAnswered || isSubmitted}
+            loading={isSubmitting}
+            onClick={() => handleSubmit(answers, cheatingCount)}
+          >
+            제출하기
+          </Button>
+        </div>
+      </main>
+
+      {/* 부정행위 경고 모달 */}
+      <CheatingWarningModal
+        count={warningModalCount}
+        isOpen={warningModalCount > 0}
+        onConfirm={handleWarningConfirm}
+        onClose={() => setWarningModalCount(0)}
+      />
+
+      {/* 제출 완료 모달 */}
+      <ExamSubmitModal
+        isOpen={submitRedirectUrl !== null}
+        onConfirm={() => {
+          if (submitRedirectUrl) navigate(submitRedirectUrl, { replace: true })
+        }}
+      />
+    </div>
+  )
+}
+
 /**
- * @figma 쪽지시험_응시하기  https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-3969&m=dev
+ * @figma 쪽지시험_응시하기  https://www.figma.com/design/zTej1hAEgfChWzZhByThtt/%EC%9D%B5%EC%8A%A4%ED%84%B4%EC%8B%AD-%EC%AA%BD%EC%A7%80%EC%8B%9C%ED%97%98?node-id=1-710
  */
 export function QuizExamPage() {
-  return <div>쪽지시험 - 응시</div>
+  const { quizId } = useParams<{ quizId: string }>()
+  const deploymentId = Number(quizId)
+
+  if (!quizId || Number.isNaN(deploymentId)) {
+    return <Navigate to="/mypage/quiz" replace />
+  }
+
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center bg-white">
+          <Spinner />
+        </div>
+      }
+    >
+      <ExamContent deploymentId={deploymentId} />
+    </Suspense>
+  )
 }


### PR DESCRIPTION
## 관련 이슈

- closes #34

## 작업 내용

- `ExamHeader` 컴포넌트 추가 (타이머, 부정행위 카운터)
- `QuestionCard` 컴포넌트 추가 (문제 유형 분기 렌더링)
- `CheatingWarningModal`, `ExamSubmitModal` 컴포넌트 추가
- `QuizExamPage` 구현 (전체 조립, 에러 처리, 전체화면 진입/해제)

## 변경 사항

- `src/components/quiz/ExamHeader/`
- `src/components/quiz/QuestionCard/`
- `src/components/quiz/CheatingWarningModal/`
- `src/components/quiz/ExamSubmitModal/`
- `src/assets/cheating/`
- `src/pages/quiz/QuizExamPage.tsx`

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다