### PR TITLE
feat: 쪽지시험 응시 페이지 URL 직접 접근 차단

### DIFF
--- a/src/components/quiz/QuizCodeModal/QuizCodeModal.tsx
+++ b/src/components/quiz/QuizCodeModal/QuizCodeModal.tsx
@@ -67,7 +67,9 @@ export function QuizCodeModal({
       { code },
       {
         onSuccess: () => {
-          navigate(ROUTES.QUIZ.EXAM.replace(':quizId', String(deploymentId)))
+          navigate(ROUTES.QUIZ.EXAM.replace(':quizId', String(deploymentId)), {
+            state: { fromCode: true },
+          })
         },
         onError: (error) => {
           if (!axios.isAxiosError<CheckCodeErrorResponse>(error)) return

--- a/src/pages/quiz/QuizExamPage.tsx
+++ b/src/pages/quiz/QuizExamPage.tsx
@@ -1,6 +1,6 @@
 import { Suspense, useState, useRef, useCallback, useEffect } from 'react'
 import { X } from 'lucide-react'
-import { useParams, useNavigate, Navigate } from 'react-router'
+import { useParams, useNavigate, useLocation, Navigate } from 'react-router'
 import axios from 'axios'
 import { Button } from '@/components/common/Button'
 import { Spinner } from '@/components/common/Spinner'
@@ -329,9 +329,14 @@ function ExamContent({ deploymentId }: ExamContentProps) {
  */
 export function QuizExamPage() {
   const { quizId } = useParams<{ quizId: string }>()
+  const location = useLocation()
   const deploymentId = Number(quizId)
 
   if (!quizId || Number.isNaN(deploymentId)) {
+    return <Navigate to="/mypage/quiz" replace />
+  }
+
+  if (!location.state?.fromCode) {
     return <Navigate to="/mypage/quiz" replace />
   }
 


### PR DESCRIPTION
## 관련 이슈

- closes #39

## 작업 내용

- `QuizCodeModal`에서 코드 인증 성공 시 `fromCode: true` state 전달
- `QuizExamPage`에서 `fromCode` 없는 접근 시 `/mypage/quiz`로 리다이렉트

## 변경 사항

- `src/components/quiz/QuizCodeModal/QuizCodeModal.tsx`
- `src/pages/quiz/QuizExamPage.tsx`

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다