### PR TITLE
fix: 쪽지시험 응시 페이지 버그 수정 (#42)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **chromium** — 기능 E2E 테스트. `e2e/` 하위의 `*.spec.ts` (`*.visual.*` 제외)
 - **visual** — 비주얼 회귀 테스트. `e2e/visual/*.visual.spec.ts`. Figma 스크린샷을 베이스라인으로 사용하며 `e2e/__screenshots__/`에 저장. `maxDiffPixelRatio: 0.1`
 
+## PR 규칙
+
+- PR base 브랜치는 항상 **`develop`** — `main`으로 절대 보내지 말 것
+
 ## 참조 문서
 
 | 문서                                   | 용도                                  |

--- a/src/components/quiz/OXQuestion/OXQuestion.tsx
+++ b/src/components/quiz/OXQuestion/OXQuestion.tsx
@@ -55,7 +55,7 @@ export function OXQuestion({ answer, onChange }: OXQuestionProps) {
             {/* 레이블 */}
             <span
               className={[
-                'flex-1 text-base leading-normal tracking-[-0.03em]',
+                'flex-1 text-left text-base leading-normal tracking-[-0.03em]',
                 isSelected ? 'text-primary' : 'text-gray-800',
               ].join(' ')}
             >

--- a/src/components/quiz/QuestionCard/QuestionCard.tsx
+++ b/src/components/quiz/QuestionCard/QuestionCard.tsx
@@ -85,23 +85,21 @@ export function QuestionCard({
   return (
     <div className="flex flex-col gap-5">
       {/* 헤더: 번호 + 문제 텍스트 + 배점/유형 뱃지 */}
-      <div className="flex items-start gap-4">
-        <div className="flex flex-1 items-start py-1">
-          <span className="w-8 shrink-0 text-xl leading-normal font-bold tracking-[-0.03em] text-gray-900">
-            {question.number}.
+      <div className="flex items-baseline gap-4 py-1">
+        <span className="w-8 shrink-0 text-xl leading-normal font-bold tracking-[-0.03em] text-gray-900">
+          {question.number}.
+        </span>
+        <p className="text-xl leading-normal font-bold tracking-[-0.03em] text-gray-900">
+          {question.question}
+          <span className="relative -top-0.5 ml-2 inline-flex items-center gap-2 align-top">
+            <span className="bg-disable rounded-sm px-3 py-2 text-xs leading-normal tracking-[-0.03em] whitespace-nowrap text-gray-900">
+              {question.point}점
+            </span>
+            <span className="bg-disable rounded-sm px-3 py-2 text-xs leading-normal tracking-[-0.03em] whitespace-nowrap text-gray-900">
+              {TYPE_LABELS[question.type]}
+            </span>
           </span>
-          <p className="text-xl leading-normal font-bold tracking-[-0.03em] text-gray-900">
-            {question.question}
-          </p>
-        </div>
-        <div className="flex shrink-0 items-center gap-2">
-          <span className="bg-disable rounded-sm px-3 py-2 text-xs leading-normal tracking-[-0.03em] whitespace-nowrap text-gray-900">
-            {question.point}점
-          </span>
-          <span className="bg-disable rounded-sm px-3 py-2 text-xs leading-normal tracking-[-0.03em] whitespace-nowrap text-gray-900">
-            {TYPE_LABELS[question.type]}
-          </span>
-        </div>
+        </p>
       </div>
 
       {/* 답안 입력 — 번호(32px) 너비만큼 들여쓰기 */}

--- a/src/hooks/useExamTimer.ts
+++ b/src/hooks/useExamTimer.ts
@@ -33,6 +33,12 @@ export function useExamTimer({
   })
 
   useEffect(() => {
+    setRemainingSeconds(Math.max(0, initialSeconds))
+  }, [initialSeconds])
+
+  useEffect(() => {
+    expiredRef.current = false
+
     const timer = setInterval(() => {
       setRemainingSeconds((prev) => {
         const next = prev - 1
@@ -55,9 +61,10 @@ export function useExamTimer({
       clearInterval(timer)
       if (expireTimeoutRef.current !== null) {
         clearTimeout(expireTimeoutRef.current)
+        expireTimeoutRef.current = null
       }
     }
-  }, [])
+  }, [initialSeconds])
 
   return {
     remainingSeconds,

--- a/src/pages/quiz/QuizExamPage.tsx
+++ b/src/pages/quiz/QuizExamPage.tsx
@@ -13,6 +13,7 @@ import { useSubmitExam } from '@/features/exams/submissions'
 import { useExamTimer } from '@/hooks/useExamTimer'
 import { useCheatingDetector } from '@/hooks/useCheatingDetector'
 import { useToastStore } from '@/stores/toastStore'
+import { ROUTES } from '@/constants/routes'
 import { HTTP_STATUS } from '@/constants/httpStatus'
 import type { Question } from '@/features/exams/deployment-detail'
 import type { SubmissionAnswer } from '@/features/exams/submissions'
@@ -28,7 +29,7 @@ const ERROR_MAP: Record<number, { fallback: string; redirect?: string }> = {
   },
   [HTTP_STATUS.UNAUTHORIZED]: {
     fallback: '로그인이 필요합니다.',
-    redirect: '/auth/login',
+    redirect: ROUTES.AUTH.LOGIN,
   },
   [HTTP_STATUS.FORBIDDEN]: {
     fallback: '권한이 없습니다.',
@@ -333,11 +334,11 @@ export function QuizExamPage() {
   const deploymentId = Number(quizId)
 
   if (!quizId || Number.isNaN(deploymentId)) {
-    return <Navigate to="/mypage/quiz" replace />
+    return <Navigate to={ROUTES.MYPAGE.QUIZ} replace />
   }
 
   if (!location.state?.fromCode) {
-    return <Navigate to="/mypage/quiz" replace />
+    return <Navigate to={ROUTES.MYPAGE.QUIZ} replace />
   }
 
   return (


### PR DESCRIPTION
## 관련 이슈

- closes #42

## 작업 내용

- OX 문제 보기 텍스트 좌측 정렬 수정
- 문제 카드 헤더 레이아웃 재구성 (배점/유형 뱃지 인라인 배치)
- 타이머 초기화 버그 수정 (`initialSeconds` 변경 시 타이머 리셋 및 만료 플래그 초기화)
- 하드코딩된 경로 문자열을 `ROUTES` 상수로 교체
- 클로드.md 파일 pr 베이스 브랜치 develop 명시

## 변경 사항

- `src/components/quiz/OXQuestion/OXQuestion.tsx` — 보기 텍스트에 `text-left` 추가
- `src/components/quiz/QuestionCard/QuestionCard.tsx` — 문제 번호·텍스트·뱃지 레이아웃 재구성
- `src/hooks/useExamTimer.ts` — `deps: []` → `[initialSeconds]`, 만료 플래그·표시 시간 리셋 effect 분리, `expireTimeoutRef` cleanup 시 null 처리 추가
- `src/pages/quiz/QuizExamPage.tsx` — `/auth/login`, `/mypage/quiz` 하드코딩 → `ROUTES` 상수 사용

## 스크린샷 (선택)

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다