### PR TITLE
feat: 소셜 로그인 구현 (#49)

### DIFF
--- a/e2e/auth/login.spec.ts
+++ b/e2e/auth/login.spec.ts
@@ -34,18 +34,15 @@ test.describe('로그인 페이지 렌더링', () => {
   })
 
   test('오즈코딩스쿨 로고가 표시된다', async ({ page }) => {
-    test.skip()
     const logo = page.getByRole('img', { name: 'OzCodingSchool' })
     await expect(logo).toBeVisible()
   })
 
   test('"아직 회원이 아니신가요?" 텍스트가 표시된다', async ({ page }) => {
-    test.skip()
     await expect(page.getByText('아직 회원이 아니신가요?')).toBeVisible()
   })
 
   test('"회원가입 하기" 링크가 표시된다', async ({ page }) => {
-    test.skip()
     await expect(
       page.getByRole('link', { name: '회원가입 하기' })
     ).toBeVisible()
@@ -54,33 +51,28 @@ test.describe('로그인 페이지 렌더링', () => {
   test('"회원가입 하기" 링크 클릭 시 /signup으로 이동한다', async ({
     page,
   }) => {
-    test.skip()
     await page.getByRole('link', { name: '회원가입 하기' }).click()
     await expect(page).toHaveURL('/signup')
   })
 
   test('"카카오 간편 로그인 / 가입" 버튼이 표시된다', async ({ page }) => {
-    test.skip()
     // SocialLoginButton의 aria-label 기준: "카카오로 계속하기"
     const kakaoButton = page.getByRole('button', { name: '카카오로 계속하기' })
     await expect(kakaoButton).toBeVisible()
   })
 
   test('"네이버 간편 로그인 / 가입" 버튼이 표시된다', async ({ page }) => {
-    test.skip()
     // SocialLoginButton의 aria-label 기준: "네이버로 계속하기"
     const naverButton = page.getByRole('button', { name: '네이버로 계속하기' })
     await expect(naverButton).toBeVisible()
   })
 
   test('이메일 입력 필드가 표시된다', async ({ page }) => {
-    test.skip()
     const emailInput = page.getByPlaceholder('아이디 (example@gmail.com)')
     await expect(emailInput).toBeVisible()
   })
 
   test('비밀번호 입력 필드가 표시된다', async ({ page }) => {
-    test.skip()
     const passwordInput = page.getByPlaceholder(
       '비밀번호 (6~15자의 영문 대소문자, 숫자, 특수문자 포함)'
     )
@@ -88,7 +80,6 @@ test.describe('로그인 페이지 렌더링', () => {
   })
 
   test('"아이디 찾기" 링크가 표시된다', async ({ page }) => {
-    test.skip()
     await expect(page.getByRole('link', { name: '아이디 찾기' })).toBeVisible()
   })
 

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -48,7 +48,11 @@ export function Header({
                 className="flex shrink-0 items-center"
                 aria-label="홈으로 이동"
               >
-                <img src={logoImg} alt="OzCodingSchool" className="h-5 w-auto" />
+                <img
+                  src={logoImg}
+                  alt="OzCodingSchool"
+                  className="h-5 w-auto"
+                />
               </button>
 
               <nav className="flex items-center gap-15">
@@ -69,9 +73,12 @@ export function Header({
 
             {/* Right: Auth or Profile */}
             {isAuthenticated && user ? (
-              <div className="relative">
+              <div
+                className="relative"
+                onMouseEnter={() => setDropdownOpen(true)}
+                onMouseLeave={() => setDropdownOpen(false)}
+              >
                 <button
-                  onMouseEnter={() => setDropdownOpen(true)}
                   onClick={() => setDropdownOpen((v) => !v)}
                   aria-label="프로필 메뉴"
                   aria-expanded={dropdownOpen}

--- a/src/components/layout/Header/ProfileDropdown.tsx
+++ b/src/components/layout/Header/ProfileDropdown.tsx
@@ -49,7 +49,7 @@ export function ProfileDropdown({
       ref={ref}
       role="menu"
       aria-label="프로필 메뉴"
-      className="absolute top-full right-0 z-50 mt-2 w-[204px] rounded-xl bg-white px-4 py-6 shadow-[0px_0px_16px_0px_rgba(160,160,160,0.25)]"
+      className="absolute top-full right-0 z-50 w-[204px] rounded-xl bg-white px-4 py-6 shadow-[0px_0px_16px_0px_rgba(160,160,160,0.25)]"
     >
       <div className="flex flex-col gap-2">
         {/* User info */}

--- a/src/features/accounts/social-login/handler.ts
+++ b/src/features/accounts/social-login/handler.ts
@@ -1,0 +1,1 @@
+export const socialLoginHandlers: never[] = []

--- a/src/features/accounts/social-login/handler.ts
+++ b/src/features/accounts/social-login/handler.ts
@@ -1,1 +1,11 @@
-export const socialLoginHandlers: never[] = []
+import { http, HttpResponse } from 'msw'
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
+
+export const socialLoginHandlers = [
+  http.post(`${BASE_URL}/accounts/me/refresh`, () => {
+    return HttpResponse.json({
+      access_token: 'mock_social_access_token',
+    })
+  }),
+]

--- a/src/features/accounts/social-login/index.ts
+++ b/src/features/accounts/social-login/index.ts
@@ -1,0 +1,3 @@
+export type { SocialLoginCallbackParams, RefreshResponse } from './types'
+export { socialLoginHandlers } from './handler'
+export { useSocialLoginCallback } from './queries'

--- a/src/features/accounts/social-login/queries.ts
+++ b/src/features/accounts/social-login/queries.ts
@@ -1,0 +1,13 @@
+import { useMutation } from '@tanstack/react-query'
+import instance from '@/api/instance'
+import type { RefreshResponse } from './types'
+
+const refreshApi = async (): Promise<RefreshResponse> => {
+  const { data } = await instance.post<RefreshResponse>('/accounts/me/refresh')
+  return data
+}
+
+export const useSocialLoginCallback = () =>
+  useMutation({
+    mutationFn: refreshApi,
+  })

--- a/src/features/accounts/social-login/types.ts
+++ b/src/features/accounts/social-login/types.ts
@@ -1,0 +1,8 @@
+export interface SocialLoginCallbackParams {
+  provider: 'kakao' | 'naver'
+  is_success: 'true' | 'false'
+}
+
+export interface RefreshResponse {
+  access_token: string
+}

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -14,6 +14,7 @@ import { cohortHandlers } from '@/features/course/cohorts/handler'
 import { enrollStudentHandlers } from '@/features/accounts/enroll-student/handler'
 import { verificationHandlers } from '@/features/accounts/verification'
 import { changePhoneHandlers } from '@/features/accounts/change-phone'
+import { socialLoginHandlers } from '@/features/accounts/social-login'
 
 export const handlers = [
   http.get('/api/health', () => {
@@ -35,4 +36,5 @@ export const handlers = [
   ...enrollStudentHandlers,
   ...verificationHandlers,
   ...changePhoneHandlers,
+  ...socialLoginHandlers,
 ]

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -27,6 +27,14 @@ export function LoginPage() {
 
   const { mutate: login, isPending } = useLogin()
 
+  const handleSocialLogin = (provider: 'kakao' | 'naver') => {
+    if (import.meta.env.DEV) {
+      window.location.href = `/social-callback?provider=${provider}&is_success=true`
+    } else {
+      window.location.href = `${import.meta.env.VITE_API_BASE_URL}/accounts/social-login/${provider}`
+    }
+  }
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
 
@@ -100,8 +108,14 @@ export function LoginPage() {
         </div>
 
         <div className="mt-12 flex w-full flex-col gap-3">
-          <SocialLoginButton provider="kakao" />
-          <SocialLoginButton provider="naver" />
+          <SocialLoginButton
+            provider="kakao"
+            onClick={() => handleSocialLogin('kakao')}
+          />
+          <SocialLoginButton
+            provider="naver"
+            onClick={() => handleSocialLogin('naver')}
+          />
         </div>
 
         <form onSubmit={handleSubmit} className="flex w-full flex-col gap-3">

--- a/src/pages/auth/SocialCallbackPage.tsx
+++ b/src/pages/auth/SocialCallbackPage.tsx
@@ -1,0 +1,53 @@
+import { useEffect } from 'react'
+import { useNavigate, useSearchParams } from 'react-router'
+import { useQueryClient } from '@tanstack/react-query'
+import { meQueries } from '@/features/accounts/me/queries'
+import { useAuthStore } from '@/stores/authStore'
+import { useSocialLoginCallback } from '@/features/accounts/social-login/queries'
+
+export function SocialCallbackPage() {
+  const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const { login: setAuth } = useAuthStore()
+  const { mutate: refresh } = useSocialLoginCallback()
+
+  useEffect(() => {
+    const isSuccess = searchParams.get('is_success')
+
+    if (isSuccess !== 'true') {
+      navigate('/login', { replace: true })
+      return
+    }
+
+    refresh(undefined, {
+      onSuccess: async (data) => {
+        localStorage.setItem('accessToken', data.access_token)
+
+        try {
+          const meData = await queryClient.fetchQuery(meQueries.detail())
+          setAuth({
+            email: meData.email,
+            nickname: meData.nickname,
+            profileImage: meData.profile_img_url,
+          })
+        } catch {
+          setAuth({ email: '', nickname: '' })
+        }
+
+        navigate('/', { replace: true })
+      },
+      onError: () => {
+        navigate('/login', { replace: true })
+      },
+    })
+  }, [])
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <p className="text-text-muted text-sm">로그인 처리 중...</p>
+    </div>
+  )
+}
+
+export default SocialCallbackPage

--- a/src/pages/auth/index.ts
+++ b/src/pages/auth/index.ts
@@ -1,1 +1,2 @@
 export { LoginPage } from './LoginPage'
+export { SocialCallbackPage } from './SocialCallbackPage'

--- a/src/providers/RouterProvider.tsx
+++ b/src/providers/RouterProvider.tsx
@@ -2,7 +2,7 @@ import { Routes, Route } from 'react-router'
 import { DefaultLayout, AuthLayout } from '@/components'
 import { MypageLayout } from '@/components/mypage'
 import { HomePage } from '@/pages/home'
-import { LoginPage } from '@/pages/auth'
+import { LoginPage, SocialCallbackPage } from '@/pages/auth'
 import { SignupSelectPage, SignupPage } from '@/pages/signup'
 import { MypagePage, MypageEditPage, ChangePasswordPage } from '@/pages/mypage'
 import { QuizListPage, QuizExamPage, QuizResultPage } from '@/pages/quiz'
@@ -14,6 +14,7 @@ export function RouterProvider() {
     <Routes>
       <Route element={<AuthLayout />}>
         <Route path="login" element={<LoginPage />} />
+        <Route path="social-callback" element={<SocialCallbackPage />} />
         <Route path="signup">
           <Route index element={<SignupSelectPage />} />
           <Route path="form" element={<SignupPage />} />


### PR DESCRIPTION
## 관련 이슈

- closes #49 

## 작업 내용

개발환경에서 버튼 클릭 시 CallbackPage로 바로 이동
// 실제 환경에서는 GET /api/v1/accounts/social-login/{provider} URL로 이동
SocialCallbackPage 구현 — me/refresh API 호출로 access_token 발급
access_token localStorage 저장 → me API 호출 → authStore 업데이트 → 메인 페이지 이동
소셜 로그인 실패 시 로그인 페이지로 이동

## 변경 사항

-소셜 로그인 버튼 클릭 시 개발환경에서 콜백 페이지로 바로 이동, 실제 환경에서는 백엔드 URL로 이동하도록 분기 처리
SocialCallbackPage 구현 — me/refresh → me API 순서로 호출하여 로그인 상태 복구
social-login 폴더 types, queries, handler, index 구현
MSW 핸들러에 me/refresh 목업 추가

## 스크린샷 (선택)
<img width="1919" height="903" alt="image" src="https://github.com/user-attachments/assets/a7370934-2f1a-48e5-85b2-5467b7cc1975" />

## 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다
- [ ] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [ ] 컨벤션에 맞게 작성했습니다
