### PR TITLE
feat: 비밀번호 변경 탭 구현(#55)

### DIFF
--- a/docs/convention/FEATURES.md
+++ b/docs/convention/FEATURES.md
@@ -30,7 +30,7 @@ src/features/
 | me-profile-image/    | `/api/v1/accounts/me/profile-image`        | PUT              |
 | me-enrolled-courses/ | `/api/v1/accounts/me/enrolled-courses`     | GET              |
 | me-refresh/          | `/api/v1/accounts/me/refresh`              | POST             |
-| change-password/     | `/api/v1/accounts/change-password`         | PUT              |
+| change-password/     | `/api/v1/accounts/change-password`         | PATCH            |
 | change-phone/        | `/api/v1/accounts/change-phone`            | PATCH            |
 | check-nickname/      | `/api/v1/accounts/check-nickname`          | POST             |
 | find-email/          | `/api/v1/accounts/find-email`              | POST             |

--- a/docs/convention/FEATURES.md
+++ b/docs/convention/FEATURES.md
@@ -30,7 +30,7 @@ src/features/
 | me-profile-image/    | `/api/v1/accounts/me/profile-image`        | PUT              |
 | me-enrolled-courses/ | `/api/v1/accounts/me/enrolled-courses`     | GET              |
 | me-refresh/          | `/api/v1/accounts/me/refresh`              | POST             |
-| change-password/     | `/api/v1/accounts/change-password`         | PATCH            |
+| change-password/     | `/api/v1/accounts/change-password`         | POST             |
 | change-phone/        | `/api/v1/accounts/change-phone`            | PATCH            |
 | check-nickname/      | `/api/v1/accounts/check-nickname`          | POST             |
 | find-email/          | `/api/v1/accounts/find-email`              | POST             |

--- a/docs/guide/API_GUIDE.md
+++ b/docs/guide/API_GUIDE.md
@@ -123,3 +123,20 @@ sms_token: 'str'
 }
 }
 }
+'POST api/v1/accounts/change-password': {
+request: {
+old_password: {
+type: 'str',
+required: 'true',
+},
+new_password: {
+type: 'str',
+required: 'true',
+},
+}
+response: {
+200: {
+detail: 'str'
+}
+}
+}

--- a/src/features/accounts/change-password/handler.ts
+++ b/src/features/accounts/change-password/handler.ts
@@ -1,0 +1,12 @@
+import { http, HttpResponse } from 'msw'
+import type { ChangePasswordResponse } from './types'
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
+
+export const changePasswordHandlers = [
+  http.post(`${BASE_URL}/accounts/change-password`, () => {
+    return HttpResponse.json<ChangePasswordResponse>({
+      detail: '비밀번호 변경 성공',
+    })
+  }),
+]

--- a/src/features/accounts/change-password/index.ts
+++ b/src/features/accounts/change-password/index.ts
@@ -1,0 +1,3 @@
+export * from './types'
+export * from './queries'
+export { changePasswordHandlers } from './handler'

--- a/src/features/accounts/change-password/queries.ts
+++ b/src/features/accounts/change-password/queries.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query'
+import api from '@/api/instance'
+import type { ChangePasswordRequest, ChangePasswordResponse } from './types'
+
+export function useChangePassword() {
+  return useMutation({
+    mutationFn: async (body: ChangePasswordRequest) => {
+      const { data } = await api.post<ChangePasswordResponse>(
+        'accounts/change-password',
+        body
+      )
+      return data
+    },
+  })
+}

--- a/src/features/accounts/change-password/types.ts
+++ b/src/features/accounts/change-password/types.ts
@@ -1,0 +1,12 @@
+export interface ChangePasswordRequest {
+  old_password: string
+  new_password: string
+}
+
+export interface ChangePasswordResponse {
+  detail: string
+}
+
+export interface ChangePasswordErrorResponse {
+  error_detail: Record<string, string[]>
+}

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -14,6 +14,7 @@ import { cohortHandlers } from '@/features/course/cohorts/handler'
 import { enrollStudentHandlers } from '@/features/accounts/enroll-student/handler'
 import { verificationHandlers } from '@/features/accounts/verification'
 import { changePhoneHandlers } from '@/features/accounts/change-phone'
+import { changePasswordHandlers } from '@/features/accounts/change-password'
 import { socialLoginHandlers } from '@/features/accounts/social-login'
 
 export const handlers = [
@@ -37,4 +38,5 @@ export const handlers = [
   ...verificationHandlers,
   ...changePhoneHandlers,
   ...socialLoginHandlers,
+  ...changePasswordHandlers,
 ]

--- a/src/pages/mypage/ChangePasswordPage.tsx
+++ b/src/pages/mypage/ChangePasswordPage.tsx
@@ -1,6 +1,159 @@
 /**
  * @figma 비밀번호 변경  https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-5510&m=dev
  */
+import { useState } from 'react'
+import { Card, Button } from '@/components'
+import {
+  PasswordInput,
+  type PasswordInputProps,
+} from '@/components/common/PasswordInput'
+import { useChangePassword } from '@/features/accounts/change-password'
+import { useToastStore } from '@/stores/toastStore'
+
+const PASSWORD_HINT = '* 6~15자의 영문 대/소문자, 숫자 및 특수문자 조합'
+const PASSWORD_REGEX =
+  /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]).{6,15}$/
+
+const LABEL_CLASS = 'text-text-heading w-[120px] shrink-0 text-base font-normal'
+const LABEL_CLASS_TOP = `${LABEL_CLASS} mt-3`
+
+interface PasswordFieldProps extends PasswordInputProps {
+  htmlFor: string
+  label: string
+  alignTop?: boolean
+}
+
+function PasswordField({
+  htmlFor,
+  label,
+  alignTop = false,
+  ...inputProps
+}: PasswordFieldProps) {
+  return (
+    <div className={`flex gap-8 ${alignTop ? 'items-start' : 'items-center'}`}>
+      <label
+        htmlFor={htmlFor}
+        className={alignTop ? LABEL_CLASS_TOP : LABEL_CLASS}
+      >
+        {label}
+      </label>
+      <div className="flex-1">
+        <PasswordInput id={htmlFor} {...inputProps} />
+      </div>
+    </div>
+  )
+}
+
 export function ChangePasswordPage() {
-  return <div>비밀번호 변경</div>
+  const [oldPassword, setOldPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const changePassword = useChangePassword()
+  const showToast = useToastStore((s) => s.show)
+
+  const confirmStatus: 'idle' | 'match' | 'mismatch' =
+    confirmPassword === ''
+      ? 'idle'
+      : newPassword === confirmPassword
+        ? 'match'
+        : 'mismatch'
+
+  const isNewPasswordValid =
+    newPassword === '' || PASSWORD_REGEX.test(newPassword)
+
+  const isSubmitDisabled =
+    !oldPassword ||
+    !newPassword ||
+    !isNewPasswordValid ||
+    !confirmPassword ||
+    confirmStatus === 'mismatch' ||
+    changePassword.isPending
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    changePassword.reset()
+    changePassword.mutate(
+      { old_password: oldPassword, new_password: newPassword },
+      {
+        onSuccess: () => {
+          setOldPassword('')
+          setNewPassword('')
+          setConfirmPassword('')
+          showToast('비밀번호가 성공적으로 변경되었습니다.', 'success')
+        },
+      }
+    )
+  }
+
+  return (
+    <div className="space-y-8">
+      <h1 className="text-text-heading text-[32px] leading-[140%] font-bold tracking-[-0.03em]">
+        비밀번호 변경
+      </h1>
+
+      <Card padding="none" elevation="sm" className="px-10 py-[52px]">
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <PasswordField
+            htmlFor="old-password"
+            label="기존 비밀번호"
+            value={oldPassword}
+            onChange={(e) => setOldPassword(e.target.value)}
+            placeholder="기존 비밀번호를 입력해주세요."
+          />
+
+          <PasswordField
+            htmlFor="new-password"
+            label="새 비밀번호"
+            alignTop
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            placeholder="새 비밀번호를 입력해주세요."
+            helperText={isNewPasswordValid ? PASSWORD_HINT : undefined}
+            errorMessage={
+              !isNewPasswordValid
+                ? '* 6~15자의 영문 대/소문자, 숫자 및 특수문자 조합이어야 합니다.'
+                : undefined
+            }
+          />
+
+          <PasswordField
+            htmlFor="confirm-password"
+            label="새 비밀번호 확인"
+            alignTop
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            placeholder="새 비밀번호를 한 번 더 입력해주세요."
+            successMessage={
+              confirmStatus === 'match' ? '* 비밀번호가 일치합니다.' : undefined
+            }
+            errorMessage={
+              confirmStatus === 'mismatch'
+                ? '* 비밀번호가 일치하지 않습니다.'
+                : undefined
+            }
+          />
+
+          {changePassword.isError && (
+            <p className="text-error text-sm">
+              비밀번호 변경에 실패했습니다. 기존 비밀번호를 확인해주세요.
+            </p>
+          )}
+
+          {/* 변경하기 버튼 - 우측 정렬 */}
+          <div className="flex justify-end pt-3">
+            <Button
+              type="submit"
+              variant="primary"
+              size="lg"
+              disabled={isSubmitDisabled}
+              loading={changePassword.isPending}
+              className="px-9 py-5"
+            >
+              변경하기
+            </Button>
+          </div>
+        </form>
+      </Card>
+    </div>
+  )
 }


### PR DESCRIPTION
## 관련 이슈

- closes #55 

## 작업 내용

- 기존 비밀번호 / 새 비밀번호 / 새 비밀번호 확인 3개 필드 구성                                                                                           
- 비밀번호 유효성 검사: 6~15자, 영문 대/소문자 + 숫자 + 특수문자 조합 (PASSWORD_REGEX)
- 실시간 확인 상태: idle / match / mismatch 3단계로 일치 여부 피드백                                                                                     
- 제출 버튼 비활성화 조건: 빈 필드, 유효성 실패, 비밀번호 불일치, 요청 중일 때                                                                           
- 성공 시: 입력 필드 초기화 + 토스트 알림 (비밀번호가 성공적으로 변경되었습니다.)                                                                        
- 에러 시: 인라인 에러 메시지 표시 (기존 비밀번호를 확인해주세요)                                                                                        
- PasswordField 내부 컴포넌트 추출로 반복 구조 정리
  
## 변경 사항

- src/features/accounts/change-password/types.ts — ChangePasswordRequest, ChangePasswordResponse, ChangePasswordErrorResponse             
- src/features/accounts/change-password/queries.ts — useChangePassword mutation  추가       
- src/features/accounts/change-password/handler.ts — MSW 모킹 핸들러 추가                                                                           
- src/features/accounts/change-password/index.ts — barrel export 추가                                                                               
- src/mocks/handlers.ts — changePasswordHandlers 핸들러 등록                                                                                             
- src/pages/mypage/ChangePasswordPage.tsx — 비밀번호 변경 페이지 구현  

## 스크린샷 (선택)

## 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다
- [ ] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [ ] 컨벤션에 맞게 작성했습니다
