### PR TITLE
feat: 쪽지시험 관리자 강제 종료 폴링 연동 (#53)

### DIFF
--- a/src/components/quiz/exam/AdminClosedModal/AdminClosedModal.tsx
+++ b/src/components/quiz/exam/AdminClosedModal/AdminClosedModal.tsx
@@ -1,0 +1,47 @@
+import { TriangleAlert } from 'lucide-react'
+import { Modal } from '@/components/common/Modal'
+import { Button } from '@/components/common/Button'
+
+interface AdminClosedModalProps {
+  isOpen: boolean
+  onConfirm: () => void
+}
+
+export function AdminClosedModal({ isOpen, onConfirm }: AdminClosedModalProps) {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onConfirm}
+      maxWidth="max-w-md"
+      hideCloseButton
+    >
+      <div className="flex flex-col items-center gap-6 py-4 text-center">
+        <div className="bg-error-bg flex h-[60px] w-[60px] items-center justify-center rounded-full">
+          <TriangleAlert
+            size={38}
+            className="text-error stroke-error-bg"
+            fill="currentColor"
+            aria-hidden="true"
+            strokeWidth={1.5}
+          />
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <h3 className="text-text-heading text-xl leading-normal font-semibold tracking-[-0.03em]">
+            관리자에 의해 시험이 <span className="text-error">종료</span>{' '}
+            되었습니다
+          </h3>
+          <div className="text-text-body flex flex-col text-base leading-normal">
+            <p>관리자에 의해 쪽지시험이 비공개 및 종료 되었습니다.</p>
+            <p>진행 중이던 답안은 저장되지 않으며 결과에 반영되지 않습니다.</p>
+            <p>쪽지시험 리스트 페이지로 이동합니다.</p>
+          </div>
+        </div>
+
+        <Button variant="primary" size="lg" fullWidth onClick={onConfirm}>
+          확인
+        </Button>
+      </div>
+    </Modal>
+  )
+}

--- a/src/components/quiz/exam/AdminClosedModal/index.ts
+++ b/src/components/quiz/exam/AdminClosedModal/index.ts
@@ -1,0 +1,1 @@
+export { AdminClosedModal } from './AdminClosedModal'

--- a/src/features/exams/deployment-detail/handler.ts
+++ b/src/features/exams/deployment-detail/handler.ts
@@ -87,6 +87,8 @@ export const deploymentDetailHandlers = [
     const url = new URL(request.url)
     // check-code 서브패스는 별도 핸들러에서 처리
     if (url.pathname.endsWith('check-code')) return
+    // status 서브패스는 별도 핸들러에서 처리
+    if (url.pathname.endsWith('status')) return
     return HttpResponse.json<DeploymentDetailResponse>(mockDetail)
   }),
 ]

--- a/src/features/exams/deployment-status/handler.ts
+++ b/src/features/exams/deployment-status/handler.ts
@@ -1,0 +1,17 @@
+import { http, HttpResponse } from 'msw'
+import type { DeploymentStatusResponse } from './types'
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
+
+// 관리자 강제 종료 테스트 시: exam_status를 'closed' 또는 force_submit을 true로 변경
+const mockStatus: DeploymentStatusResponse = {
+  exam_status: 'activated',
+  force_submit: false,
+}
+
+// GET /api/v1/exams/deployments/:deploymentId/status — 쪽지시험 배포 상태 폴링 API
+export const deploymentStatusHandlers = [
+  http.get(`${BASE_URL}/exams/deployments/:deploymentId/status`, () => {
+    return HttpResponse.json<DeploymentStatusResponse>(mockStatus)
+  }),
+]

--- a/src/features/exams/deployment-status/index.ts
+++ b/src/features/exams/deployment-status/index.ts
@@ -1,0 +1,3 @@
+export type { DeploymentStatusResponse } from './types'
+export { deploymentStatusQueries, useDeploymentStatus } from './queries'
+export { deploymentStatusHandlers } from './handler'

--- a/src/features/exams/deployment-status/queries.ts
+++ b/src/features/exams/deployment-status/queries.ts
@@ -1,0 +1,40 @@
+import { queryOptions, useQuery } from '@tanstack/react-query'
+import api from '@/api/instance'
+import { getErrorStatus } from '@/utils/getErrorStatus'
+import type { DeploymentStatusResponse } from './types'
+
+const STATUS_POLL_INTERVAL_MS = 15_000
+
+export const deploymentStatusQueries = {
+  status: (deploymentId: number) =>
+    queryOptions({
+      queryKey: ['exams', 'deployments', deploymentId, 'status'],
+      queryFn: async () => {
+        const { data } = await api.get<DeploymentStatusResponse>(
+          `exams/deployments/${deploymentId}/status`
+        )
+        return data
+      },
+      refetchInterval: (query) => {
+        const d = query.state.data
+        if (!d) return STATUS_POLL_INTERVAL_MS
+        return d.exam_status === 'closed' || d.force_submit
+          ? false
+          : STATUS_POLL_INTERVAL_MS
+      },
+      refetchIntervalInBackground: false,
+      // 4xx는 재시도 불필요, 5xx/네트워크 에러는 최대 2회 재시도
+      retry: (failureCount, error) => {
+        const status = getErrorStatus(error)
+        if (status && status < 500) return false
+        return failureCount < 2
+      },
+      staleTime: 0,
+      gcTime: 0,
+    }),
+}
+
+// useSuspenseQuery 미사용: 폴링 중 Suspense fallback이 반복 발생하지 않도록 useQuery 사용
+export function useDeploymentStatus(deploymentId: number, enabled = true) {
+  return useQuery({ ...deploymentStatusQueries.status(deploymentId), enabled })
+}

--- a/src/features/exams/deployment-status/types.ts
+++ b/src/features/exams/deployment-status/types.ts
@@ -1,0 +1,4 @@
+export interface DeploymentStatusResponse {
+  exam_status: 'activated' | 'closed'
+  force_submit: boolean
+}

--- a/src/hooks/useExamStatusPoller.ts
+++ b/src/hooks/useExamStatusPoller.ts
@@ -1,51 +1,57 @@
 import { useEffect, useRef } from 'react'
+import { useNavigate } from 'react-router'
 import { useDeploymentStatus } from '@/features/exams/deployment-status'
+import { useToastStore } from '@/stores/toastStore'
 import { getErrorStatus } from '@/utils/getErrorStatus'
+import { getErrorDetail } from '@/utils/getErrorDetail'
 import { HTTP_STATUS } from '@/constants/httpStatus'
+import { ROUTES } from '@/constants/routes'
 
-interface UseExamStatusPollerOptions {
-  deploymentId: number
-  enabled: boolean
-  onClosed: () => void
-  onError: (status: number | undefined, error: unknown) => void
+function exitFullscreen() {
+  if (document.fullscreenElement) document.exitFullscreen().catch(() => {})
 }
 
-export function useExamStatusPoller({
-  deploymentId,
-  enabled,
-  onClosed,
-  onError,
-}: UseExamStatusPollerOptions) {
+export function useExamStatusPoller(
+  deploymentId: number,
+  enabled: boolean,
+  setIsAdminClosed: (value: boolean) => void
+) {
+  const navigate = useNavigate()
+  const showToast = useToastStore((s) => s.show)
   const { data, error } = useDeploymentStatus(deploymentId, enabled)
-  const onClosedRef = useRef(onClosed)
-  const onErrorRef = useRef(onError)
   const triggeredRef = useRef(false)
 
   useEffect(() => {
-    onClosedRef.current = onClosed
-    onErrorRef.current = onError
-  })
-
-  useEffect(() => {
-    if (!data || triggeredRef.current) return
+    if (triggeredRef.current || !data) return
     if (data.exam_status === 'closed' || data.force_submit === true) {
       triggeredRef.current = true
-      onClosedRef.current()
+      exitFullscreen()
+      setIsAdminClosed(true)
     }
-  }, [data])
+  }, [data, setIsAdminClosed])
 
   useEffect(() => {
-    if (!error || triggeredRef.current) return
+    if (triggeredRef.current || !error) return
     const status = getErrorStatus(error)
     if (status === HTTP_STATUS.GONE) {
       // 410: 시험 종료 신호 — closed로 처리
       triggeredRef.current = true
-      onClosedRef.current()
+      exitFullscreen()
+      setIsAdminClosed(true)
     } else if (status && status >= 400 && status < 500) {
       // 4xx: 명확한 에러 — 종결 처리
       triggeredRef.current = true
-      onErrorRef.current(status, error)
+      exitFullscreen()
+      if (status === HTTP_STATUS.UNAUTHORIZED) {
+        navigate(ROUTES.AUTH.LOGIN, { replace: true })
+      } else {
+        showToast(
+          getErrorDetail(error) ?? '시험 상태 확인 중 오류가 발생했습니다.',
+          'error'
+        )
+        navigate(ROUTES.MYPAGE.QUIZ, { replace: true })
+      }
     }
     // 5xx/네트워크 에러: retry 정책으로 흡수, triggeredRef 잠금하지 않아 폴링 지속
-  }, [error])
+  }, [error, navigate, showToast, setIsAdminClosed])
 }

--- a/src/hooks/useExamStatusPoller.ts
+++ b/src/hooks/useExamStatusPoller.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from 'react'
+import { useDeploymentStatus } from '@/features/exams/deployment-status'
+import { getErrorStatus } from '@/utils/getErrorStatus'
+import { HTTP_STATUS } from '@/constants/httpStatus'
+
+interface UseExamStatusPollerOptions {
+  deploymentId: number
+  enabled: boolean
+  onClosed: () => void
+  onError: (status: number | undefined, error: unknown) => void
+}
+
+export function useExamStatusPoller({
+  deploymentId,
+  enabled,
+  onClosed,
+  onError,
+}: UseExamStatusPollerOptions) {
+  const { data, error } = useDeploymentStatus(deploymentId, enabled)
+  const onClosedRef = useRef(onClosed)
+  const onErrorRef = useRef(onError)
+  const triggeredRef = useRef(false)
+
+  useEffect(() => {
+    onClosedRef.current = onClosed
+    onErrorRef.current = onError
+  })
+
+  useEffect(() => {
+    if (!data || triggeredRef.current) return
+    if (data.exam_status === 'closed' || data.force_submit === true) {
+      triggeredRef.current = true
+      onClosedRef.current()
+    }
+  }, [data])
+
+  useEffect(() => {
+    if (!error || triggeredRef.current) return
+    const status = getErrorStatus(error)
+    if (status === HTTP_STATUS.GONE) {
+      // 410: 시험 종료 신호 — closed로 처리
+      triggeredRef.current = true
+      onClosedRef.current()
+    } else if (status && status >= 400 && status < 500) {
+      // 4xx: 명확한 에러 — 종결 처리
+      triggeredRef.current = true
+      onErrorRef.current(status, error)
+    }
+    // 5xx/네트워크 에러: retry 정책으로 흡수, triggeredRef 잠금하지 않아 폴링 지속
+  }, [error])
+}

--- a/src/hooks/useExamTimer.ts
+++ b/src/hooks/useExamTimer.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 
 interface UseExamTimerOptions {
   initialSeconds: number
+  enabled?: boolean
   onExpire: () => void
 }
 
@@ -11,6 +12,7 @@ interface UseExamTimerResult {
 
 export function useExamTimer({
   initialSeconds,
+  enabled = true,
   onExpire,
 }: UseExamTimerOptions): UseExamTimerResult {
   const [remainingSeconds, setRemainingSeconds] = useState(
@@ -30,6 +32,8 @@ export function useExamTimer({
   }, [initialSeconds])
 
   useEffect(() => {
+    if (!enabled) return
+
     expiredRef.current = false
 
     const timer = setInterval(() => {
@@ -57,7 +61,7 @@ export function useExamTimer({
         expireTimeoutRef.current = null
       }
     }
-  }, [initialSeconds])
+  }, [initialSeconds, enabled])
 
   return { remainingSeconds }
 }

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -7,6 +7,7 @@ import { checkCodeHandlers } from '@/features/exams/deployment-check-code'
 import { checkNicknameHandlers } from '@/features/accounts/check-nickname'
 import { meProfileImageHandlers } from '@/features/accounts/me-profile-image'
 import { deploymentDetailHandlers } from '@/features/exams/deployment-detail'
+import { deploymentStatusHandlers } from '@/features/exams/deployment-status'
 import { submissionsHandlers } from '@/features/exams/submissions'
 import { logoutHandlers } from '@/features/accounts/logout'
 import { courseListHandlers } from '@/features/course/list/handler'
@@ -25,7 +26,8 @@ export const handlers = [
   ...meEnrolledCoursesHandlers,
   ...deploymentsHandlers,
   ...loginHandlers,
-  // check-code는 deploymentDetail보다 먼저 등록해 패스 우선순위 확보
+  // status / check-code는 deploymentDetail보다 먼저 등록해 패스 우선순위 확보
+  ...deploymentStatusHandlers,
   ...checkCodeHandlers,
   ...checkNicknameHandlers,
   ...meProfileImageHandlers,

--- a/src/pages/quiz/QuizExamPage.tsx
+++ b/src/pages/quiz/QuizExamPage.tsx
@@ -72,28 +72,7 @@ function ExamContent({ deploymentId }: ExamContentProps) {
 
   const isExamActive = !isSubmitted && !isAdminClosed
 
-  useExamStatusPoller({
-    deploymentId,
-    enabled: isExamActive,
-    onClosed: () => {
-      if (document.fullscreenElement) document.exitFullscreen().catch(() => {})
-      setIsAdminClosed(true)
-    },
-    onError: (status, error) => {
-      if (document.fullscreenElement) document.exitFullscreen().catch(() => {})
-      if (status === HTTP_STATUS.UNAUTHORIZED) {
-        navigate(ROUTES.AUTH.LOGIN, { replace: true })
-      } else {
-        const config = status ? ERROR_MAP[status] : undefined
-        const message =
-          getErrorDetail(error) ??
-          config?.fallback ??
-          '시험 상태 확인 중 오류가 발생했습니다.'
-        showToast(message, 'error')
-        navigate(ROUTES.MYPAGE.QUIZ, { replace: true })
-      }
-    },
-  })
+  useExamStatusPoller(deploymentId, isExamActive, setIsAdminClosed)
 
   // 사용자 제스처(버튼 클릭) 이후 fullscreen 진입 및 시험 시작 상태
   const startedAt = useRef(new Date().toISOString().slice(0, 19))

--- a/src/pages/quiz/QuizExamPage.tsx
+++ b/src/pages/quiz/QuizExamPage.tsx
@@ -6,11 +6,13 @@ import { Spinner } from '@/components/common/Spinner'
 import { Modal } from '@/components/common/Modal'
 import { ExamHeader } from '@/components/quiz/exam/ExamHeader'
 import { CheatingWarningModal } from '@/components/quiz/exam/CheatingWarningModal'
+import { AdminClosedModal } from '@/components/quiz/exam/AdminClosedModal'
 import { QuestionCard } from '@/components/quiz/exam/QuestionCard'
 import { useDeploymentDetail } from '@/features/exams/deployment-detail'
 import { useSubmitExam } from '@/features/exams/submissions'
 import { useExamTimer } from '@/hooks/useExamTimer'
 import { useCheatingDetector } from '@/hooks/useCheatingDetector'
+import { useExamStatusPoller } from '@/hooks/useExamStatusPoller'
 import { useToastStore } from '@/stores/toastStore'
 import { ROUTES } from '@/constants/routes'
 import { HTTP_STATUS } from '@/constants/httpStatus'
@@ -22,7 +24,7 @@ import type { SubmissionAnswer } from '@/features/exams/submissions'
 const ERROR_MAP: Record<number, { fallback: string; redirect?: string }> = {
   [HTTP_STATUS.BAD_REQUEST]: {
     fallback: '유효하지 않은 시험 응시 세션입니다.',
-    redirect: '/mypage/quiz',
+    redirect: ROUTES.MYPAGE.QUIZ,
   },
   [HTTP_STATUS.UNAUTHORIZED]: {
     fallback: '로그인이 필요합니다.',
@@ -30,16 +32,16 @@ const ERROR_MAP: Record<number, { fallback: string; redirect?: string }> = {
   },
   [HTTP_STATUS.FORBIDDEN]: {
     fallback: '권한이 없습니다.',
-    redirect: '/mypage/quiz',
+    redirect: ROUTES.MYPAGE.QUIZ,
   },
   [HTTP_STATUS.NOT_FOUND]: {
     fallback: '해당 시험 정보를 찾을 수 없습니다.',
-    redirect: '/mypage/quiz',
+    redirect: ROUTES.MYPAGE.QUIZ,
   },
   [HTTP_STATUS.CONFLICT]: { fallback: '이미 제출된 시험입니다.' },
   [HTTP_STATUS.GONE]: {
     fallback: '시험이 종료되었습니다.',
-    redirect: '/mypage/quiz',
+    redirect: ROUTES.MYPAGE.QUIZ,
   },
 }
 
@@ -63,9 +65,36 @@ function ExamContent({ deploymentId }: ExamContentProps) {
   const [showWarningBanner, setShowWarningBanner] = useState(true)
   const [warningModalCount, setWarningModalCount] = useState(0)
   const [isSubmitted, setIsSubmitted] = useState(false)
+  const [isAdminClosed, setIsAdminClosed] = useState(false)
   const [submitRedirectUrl, setSubmitRedirectUrl] = useState<string | null>(
     null
   )
+
+  const isExamActive = !isSubmitted && !isAdminClosed
+
+  useExamStatusPoller({
+    deploymentId,
+    enabled: isExamActive,
+    onClosed: () => {
+      if (document.fullscreenElement) document.exitFullscreen().catch(() => {})
+      setIsAdminClosed(true)
+    },
+    onError: (status, error) => {
+      if (document.fullscreenElement) document.exitFullscreen().catch(() => {})
+      if (status === HTTP_STATUS.UNAUTHORIZED) {
+        navigate(ROUTES.AUTH.LOGIN, { replace: true })
+      } else {
+        const config = status ? ERROR_MAP[status] : undefined
+        const message =
+          getErrorDetail(error) ??
+          config?.fallback ??
+          '시험 상태 확인 중 오류가 발생했습니다.'
+        showToast(message, 'error')
+        navigate(ROUTES.MYPAGE.QUIZ, { replace: true })
+      }
+    },
+  })
+
   // 사용자 제스처(버튼 클릭) 이후 fullscreen 진입 및 시험 시작 상태
   const startedAt = useRef(new Date().toISOString().slice(0, 19))
 
@@ -143,7 +172,7 @@ function ExamContent({ deploymentId }: ExamContentProps) {
   const { cheatingCount } = useCheatingDetector({
     initialCount: cheating_count,
     onDetect: (count) => setWarningModalCount(count),
-    enabled: !isSubmitted,
+    enabled: isExamActive,
   })
 
   const handleTimerExpire = useCallback(() => {
@@ -154,6 +183,7 @@ function ExamContent({ deploymentId }: ExamContentProps) {
 
   const { remainingSeconds } = useExamTimer({
     initialSeconds: duration_time * 60 - elapsed_time,
+    enabled: isExamActive,
     onExpire: handleTimerExpire,
   })
 
@@ -179,7 +209,7 @@ function ExamContent({ deploymentId }: ExamContentProps) {
     if (document.fullscreenElement) {
       document.exitFullscreen().catch(() => {})
     }
-    navigate('/mypage/quiz')
+    navigate(ROUTES.MYPAGE.QUIZ)
   }, [navigate])
 
   return (
@@ -262,6 +292,12 @@ function ExamContent({ deploymentId }: ExamContentProps) {
         onClose={() => setWarningModalCount(0)}
       />
 
+      {/* 관리자 종료 모달 */}
+      <AdminClosedModal
+        isOpen={isAdminClosed}
+        onConfirm={() => navigate(ROUTES.MYPAGE.QUIZ, { replace: true })}
+      />
+
       {/* 제출 완료 모달 */}
       <Modal
         isOpen={submitRedirectUrl !== null}
@@ -309,7 +345,7 @@ export function QuizExamPage() {
   const location = useLocation()
   const deploymentId = Number(quizId)
 
-  if (!quizId || Number.isNaN(deploymentId)) {
+  if (!quizId || Number.isNaN(deploymentId) || deploymentId <= 0) {
     return <Navigate to={ROUTES.MYPAGE.QUIZ} replace />
   }
 
@@ -325,7 +361,7 @@ export function QuizExamPage() {
         </div>
       }
     >
-      <ExamContent deploymentId={deploymentId} />
+      <ExamContent key={deploymentId} deploymentId={deploymentId} />
     </Suspense>
   )
 }

--- a/src/providers/QueryProvider.tsx
+++ b/src/providers/QueryProvider.tsx
@@ -12,8 +12,10 @@ export function QueryProvider({ children }: { children: React.ReactNode }) {
             refetchOnWindowFocus: false,
           },
         },
-      }),
+      })
   )
 
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
 }


### PR DESCRIPTION
## 관련 이슈

- closes #53

## 작업 내용

- 쪽지시험 배포 상태 폴링 API 모듈 추가 (`/exams/deployments/:id/status`)
- 시험 상태 폴링 훅 추가 (`useExamStatusPoller`)
- 관리자 강제 종료 모달 컴포넌트 추가 (`AdminClosedModal`)
- 시험 응시 페이지에 폴링 연동 — 관리자 종료 감지 시 모달 표시 후 목록으로 이동

## 변경 사항

- `src/features/exams/deployment-status/` — 폴링 API 모듈 (types, queries, handler, index)
- `src/hooks/useExamStatusPoller.ts` — 상태 폴링 훅. `exam_status === 'closed'` 또는 `force_submit === true` 감지 시 콜백 1회 실행
- `src/hooks/useExamTimer.ts` — `enabled` 옵션 추가. 관리자 종료/제출 후 타이머 정지
- `src/components/quiz/exam/AdminClosedModal/` — 관리자 종료 안내 모달
- `src/pages/quiz/QuizExamPage.tsx` — 폴링 연동, `isExamActive` 기반으로 폴링·타이머·부정행위 감지 비활성화

## 스크린샷 (선택)

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다