### PR TITLE
refactor: accessToken 인메모리 전환 (#59)

### DIFF
--- a/src/api/interceptors.ts
+++ b/src/api/interceptors.ts
@@ -26,7 +26,6 @@ const processQueue = (error: unknown, token: string | null) => {
   pendingQueue = []
 }
 
-
 export function setupInterceptors(instance: AxiosInstance): void {
   instance.interceptors.request.use(
     (config) => {

--- a/src/api/interceptors.ts
+++ b/src/api/interceptors.ts
@@ -1,4 +1,3 @@
-import axios from 'axios'
 import type {
   AxiosInstance,
   InternalAxiosRequestConfig,
@@ -13,7 +12,6 @@ interface RetryConfig extends InternalAxiosRequestConfig {
 
 const redirectToLogin = () => {
   useAuthStore.getState().logout()
-  localStorage.removeItem('accessToken')
 
   if (window.location.pathname !== ROUTES.AUTH.LOGIN) {
     window.location.href = ROUTES.AUTH.LOGIN
@@ -23,7 +21,7 @@ const redirectToLogin = () => {
 export function setupInterceptors(instance: AxiosInstance): void {
   instance.interceptors.request.use(
     (config) => {
-      const token = localStorage.getItem('accessToken')
+      const token = useAuthStore.getState().accessToken
       if (token && config.headers) {
         config.headers.Authorization = `Bearer ${token}`
       }
@@ -41,18 +39,24 @@ export function setupInterceptors(instance: AxiosInstance): void {
         return Promise.reject(error)
       }
 
+      // me/refresh 요청 자체가 401이면 재시도 안 함
+      if (originalConfig.url?.includes('me/refresh')) {
+        redirectToLogin()
+        return Promise.reject(error)
+      }
+
       if (error.response.status === 401 && !originalConfig._retry) {
         originalConfig._retry = true
 
         try {
-          const { data } = await axios.post(
-            `${import.meta.env.VITE_API_BASE_URL}/accounts/me/refresh`,
+          const { data } = await instance.post(
+            '/accounts/me/refresh',
             {},
             { withCredentials: true }
           )
 
           const newToken = data.access_token
-          localStorage.setItem('accessToken', newToken)
+          useAuthStore.getState().setAccessToken(newToken)
 
           originalConfig.headers.Authorization = `Bearer ${newToken}`
           return instance(originalConfig)

--- a/src/api/interceptors.ts
+++ b/src/api/interceptors.ts
@@ -3,7 +3,6 @@ import type {
   InternalAxiosRequestConfig,
   AxiosError,
 } from 'axios'
-import { ROUTES } from '@/constants/routes'
 import { useAuthStore } from '@/stores/authStore'
 
 interface RetryConfig extends InternalAxiosRequestConfig {
@@ -27,13 +26,6 @@ const processQueue = (error: unknown, token: string | null) => {
   pendingQueue = []
 }
 
-const redirectToLogin = () => {
-  useAuthStore.getState().logout()
-
-  if (window.location.pathname !== ROUTES.AUTH.LOGIN) {
-    window.location.href = ROUTES.AUTH.LOGIN
-  }
-}
 
 export function setupInterceptors(instance: AxiosInstance): void {
   instance.interceptors.request.use(
@@ -57,7 +49,6 @@ export function setupInterceptors(instance: AxiosInstance): void {
       }
 
       if (originalConfig.url === REFRESH_URL) {
-        redirectToLogin()
         return Promise.reject(error)
       }
 
@@ -92,7 +83,7 @@ export function setupInterceptors(instance: AxiosInstance): void {
           return instance(originalConfig)
         } catch (refreshError) {
           processQueue(refreshError, null)
-          redirectToLogin()
+          useAuthStore.getState().logout()
           return Promise.reject(refreshError)
         } finally {
           isRefreshing = false

--- a/src/api/interceptors.ts
+++ b/src/api/interceptors.ts
@@ -10,6 +10,23 @@ interface RetryConfig extends InternalAxiosRequestConfig {
   _retry?: boolean
 }
 
+interface PendingRequest {
+  resolve: (token: string) => void
+  reject: (err: unknown) => void
+}
+
+const REFRESH_URL = '/accounts/me/refresh'
+
+let isRefreshing = false
+let pendingQueue: PendingRequest[] = []
+
+const processQueue = (error: unknown, token: string | null) => {
+  pendingQueue.forEach(({ resolve, reject }) =>
+    error ? reject(error) : resolve(token!)
+  )
+  pendingQueue = []
+}
+
 const redirectToLogin = () => {
   useAuthStore.getState().logout()
 
@@ -39,8 +56,7 @@ export function setupInterceptors(instance: AxiosInstance): void {
         return Promise.reject(error)
       }
 
-      // me/refresh 요청 자체가 401이면 재시도 안 함
-      if (originalConfig.url?.includes('me/refresh')) {
+      if (originalConfig.url === REFRESH_URL) {
         redirectToLogin()
         return Promise.reject(error)
       }
@@ -48,21 +64,38 @@ export function setupInterceptors(instance: AxiosInstance): void {
       if (error.response.status === 401 && !originalConfig._retry) {
         originalConfig._retry = true
 
+        if (isRefreshing) {
+          return new Promise<string>((resolve, reject) => {
+            pendingQueue.push({ resolve, reject })
+          }).then((token) => {
+            originalConfig.headers.Authorization = `Bearer ${token}`
+            return instance(originalConfig)
+          })
+        }
+
+        isRefreshing = true
+
         try {
           const { data } = await instance.post(
-            '/accounts/me/refresh',
+            REFRESH_URL,
             {},
-            { withCredentials: true }
+            {
+              withCredentials: true,
+            }
           )
 
-          const newToken = data.access_token
+          const newToken: string = data.access_token
           useAuthStore.getState().setAccessToken(newToken)
+          processQueue(null, newToken)
 
           originalConfig.headers.Authorization = `Bearer ${newToken}`
           return instance(originalConfig)
         } catch (refreshError) {
+          processQueue(refreshError, null)
           redirectToLogin()
           return Promise.reject(refreshError)
+        } finally {
+          isRefreshing = false
         }
       }
 

--- a/src/components/common/ProtectedRoute/ProtectedRoute.tsx
+++ b/src/components/common/ProtectedRoute/ProtectedRoute.tsx
@@ -2,7 +2,9 @@ import { Navigate } from 'react-router'
 import { useAuthStore } from '@/stores/authStore'
 
 export function ProtectedRoute({ children }: { children: React.ReactNode }) {
-  const { isAuthenticated } = useAuthStore()
+  const { isAuthenticated, isLoading } = useAuthStore()
+
+  if (isLoading) return null
 
   if (!isAuthenticated) {
     return <Navigate to="/login" replace />

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -115,7 +115,6 @@ export function Header({
                     logoutApi(undefined, {
                       onSettled: () => {
                         logout()
-                        document.cookie = 'refresh_token=; Max-Age=0; path=/'
                         queryClient.clear()
                         setDropdownOpen(false)
                       },

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -21,7 +21,7 @@ export function Header({
   const [enrollModalOpen, setEnrollModalOpen] = useState(false)
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const { isAuthenticated, user, logout } = useAuthStore()
+  const { isAuthenticated, isLoading, user, logout } = useAuthStore()
   const { mutate: logoutApi } = useLogout()
 
   const { data: enrolledCourses } = useQuery({
@@ -72,7 +72,9 @@ export function Header({
             </div>
 
             {/* Right: Auth or Profile */}
-            {isAuthenticated && user ? (
+            {isLoading ? (
+              <div className="h-10 w-10" />
+            ) : isAuthenticated && user ? (
               <div
                 className="relative"
                 onMouseEnter={() => setDropdownOpen(true)}
@@ -113,7 +115,7 @@ export function Header({
                     logoutApi(undefined, {
                       onSettled: () => {
                         logout()
-                        localStorage.removeItem('accessToken')
+                        document.cookie = 'refresh_token=; Max-Age=0; path=/'
                         queryClient.clear()
                         setDropdownOpen(false)
                       },

--- a/src/features/accounts/login/handler.ts
+++ b/src/features/accounts/login/handler.ts
@@ -19,9 +19,15 @@ export const loginHandlers = [
     }
 
     if (body.email === 'test@test.com' && body.password === 'Test1234!@') {
-      return HttpResponse.json(
-        { access_token: 'mock_access_token' },
-        { status: 200 }
+      return new HttpResponse(
+        JSON.stringify({ access_token: 'access_token' }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+            'Set-Cookie': 'refresh_token=refresh_token; HttpOnly; SameSite=Lax',
+          },
+        }
       )
     }
 

--- a/src/features/accounts/logout/handler.ts
+++ b/src/features/accounts/logout/handler.ts
@@ -4,6 +4,15 @@ const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
 
 export const logoutHandlers = [
   http.post(`${BASE_URL}/accounts/logout`, () => {
-    return HttpResponse.json({ detail: '로그아웃 되었습니다.' })
+    return new HttpResponse(
+      JSON.stringify({ detail: '로그아웃 되었습니다.' }),
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'Set-Cookie': 'refresh_token=; HttpOnly; SameSite=Lax; Max-Age=0',
+        },
+      }
+    )
   }),
 ]

--- a/src/features/accounts/social-login/handler.ts
+++ b/src/features/accounts/social-login/handler.ts
@@ -3,9 +3,18 @@ import { http, HttpResponse } from 'msw'
 const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
 
 export const socialLoginHandlers = [
-  http.post(`${BASE_URL}/accounts/me/refresh`, () => {
+  http.post(`${BASE_URL}/accounts/me/refresh`, ({ cookies }) => {
+    const refreshToken = cookies.refresh_token
+
+    if (!refreshToken) {
+      return HttpResponse.json(
+        { error_detail: '자격 인증 데이터가 제공되지 않았습니다.' },
+        { status: 401 }
+      )
+    }
+
     return HttpResponse.json({
-      access_token: 'mock_social_access_token',
+      access_token: 'access_token',
     })
   }),
 ]

--- a/src/features/accounts/social-login/queries.ts
+++ b/src/features/accounts/social-login/queries.ts
@@ -3,7 +3,11 @@ import instance from '@/api/instance'
 import type { RefreshResponse } from './types'
 
 const refreshApi = async (): Promise<RefreshResponse> => {
-  const { data } = await instance.post<RefreshResponse>('/accounts/me/refresh')
+  const { data } = await instance.post<RefreshResponse>(
+    '/accounts/me/refresh',
+    {},
+    { withCredentials: true }
+  )
   return data
 }
 

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -29,6 +29,7 @@ export function LoginPage() {
 
   const handleSocialLogin = (provider: 'kakao' | 'naver') => {
     if (import.meta.env.DEV) {
+      document.cookie = 'refresh_token=refresh_token; SameSite=Lax; path=/'
       window.location.href = `/social-callback?provider=${provider}&is_success=true`
     } else {
       window.location.href = `${import.meta.env.VITE_API_BASE_URL}/accounts/social-login/${provider}`
@@ -51,17 +52,21 @@ export function LoginPage() {
       { email, password },
       {
         onSuccess: async (data) => {
-          localStorage.setItem('accessToken', data.access_token)
+          const accessToken = data.access_token
 
           try {
+            useAuthStore.getState().setAccessToken(accessToken)
             const meData = await queryClient.fetchQuery(meQueries.detail())
-            setAuth({
-              email: meData.email,
-              nickname: meData.nickname,
-              profileImage: meData.profile_img_url,
-            })
+            setAuth(
+              {
+                email: meData.email,
+                nickname: meData.nickname,
+                profileImage: meData.profile_img_url,
+              },
+              accessToken
+            )
           } catch {
-            setAuth({ email, nickname: '' })
+            setAuth({ email, nickname: '' }, accessToken)
           }
 
           navigate('/')

--- a/src/pages/auth/SocialCallbackPage.tsx
+++ b/src/pages/auth/SocialCallbackPage.tsx
@@ -22,18 +22,22 @@ export function SocialCallbackPage() {
 
     refresh(undefined, {
       onSuccess: async (data) => {
-        localStorage.setItem('accessToken', data.access_token)
+        const accessToken = data.access_token
+        useAuthStore.getState().setAccessToken(accessToken)
 
         try {
           const meData = await queryClient.fetchQuery(meQueries.detail())
-          setAuth({
-            email: meData.email,
-            nickname: meData.nickname,
-            profileImage: meData.profile_img_url,
-          })
+          setAuth(
+            {
+              email: meData.email,
+              nickname: meData.nickname,
+              profileImage: meData.profile_img_url,
+            },
+            accessToken
+          )
           navigate('/', { replace: true })
         } catch {
-          localStorage.removeItem('accessToken')
+          useAuthStore.getState().logout()
           navigate('/login', { replace: true })
         }
       },
@@ -41,7 +45,7 @@ export function SocialCallbackPage() {
         navigate('/login', { replace: true })
       },
     })
-  }, [])
+  }, [navigate, queryClient, refresh, searchParams, setAuth])
 
   return (
     <div className="flex min-h-screen items-center justify-center">
@@ -49,3 +53,5 @@ export function SocialCallbackPage() {
     </div>
   )
 }
+
+export default SocialCallbackPage

--- a/src/pages/auth/SocialCallbackPage.tsx
+++ b/src/pages/auth/SocialCallbackPage.tsx
@@ -53,5 +53,3 @@ export function SocialCallbackPage() {
     </div>
   )
 }
-
-export default SocialCallbackPage

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -2,33 +2,37 @@ import { useEffect } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { meQueries } from '@/features/accounts/me'
 import { useAuthStore } from '@/stores/authStore'
+import instance from '@/api/instance'
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const queryClient = useQueryClient()
-  const { login: setAuth, setLoading } = useAuthStore()
+  const { login: setAuth, setLoading, setAccessToken } = useAuthStore()
 
   useEffect(() => {
-    const token = localStorage.getItem('accessToken')
-    if (!token) return
-
-    queryClient
-      .fetchQuery(meQueries.detail())
+    instance
+      .post('/accounts/me/refresh')
+      .then(({ data }) => {
+        setAccessToken(data.access_token)
+        return queryClient.fetchQuery(meQueries.detail())
+      })
       .then((meData) => {
-        setAuth({
-          email: meData.email,
-          nickname: meData.nickname,
-          profileImage: meData.profile_img_url,
-        })
+        setAuth(
+          {
+            email: meData.email,
+            nickname: meData.nickname,
+            profileImage: meData.profile_img_url,
+          },
+          useAuthStore.getState().accessToken ?? ''
+        )
       })
       .catch(() => {
-        localStorage.removeItem('accessToken')
         queryClient.clear()
         useAuthStore.getState().logout()
       })
       .finally(() => {
         setLoading(false)
       })
-  }, [queryClient, setAuth, setLoading])
+  }, [queryClient, setAuth, setLoading, setAccessToken])
 
   return <>{children}</>
 }

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -10,7 +10,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     instance
-      .post('/accounts/me/refresh')
+      .post('/accounts/me/refresh', {}, { withCredentials: true })
       .then(({ data }) => {
         setAccessToken(data.access_token)
         return queryClient.fetchQuery(meQueries.detail())

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -11,32 +11,42 @@ interface User {
 interface AuthState {
   isAuthenticated: boolean
   isLoading: boolean
+  accessToken: string | null
   user: User | null
-  login: (user: User) => void
+  login: (user: User, accessToken: string) => void
   logout: () => void
   setLoading: (loading: boolean) => void
+  setAccessToken: (token: string) => void
 }
 
 export const useAuthStore = create<AuthState>()(
   devtools(
     (set) => ({
-      isAuthenticated: !!localStorage.getItem('accessToken'),
-      isLoading: !!localStorage.getItem('accessToken'),
+      isAuthenticated: false,
+      isLoading: true,
+      accessToken: null,
       user: null,
-      login: (user) =>
+      login: (user, accessToken) =>
         set(
-          { isAuthenticated: true, isLoading: false, user },
+          { isAuthenticated: true, isLoading: false, user, accessToken },
           undefined,
           'auth/login'
         ),
       logout: () =>
         set(
-          { isAuthenticated: false, isLoading: false, user: null },
+          {
+            isAuthenticated: false,
+            isLoading: false,
+            user: null,
+            accessToken: null,
+          },
           undefined,
           'auth/logout'
         ),
       setLoading: (loading) =>
         set({ isLoading: loading }, undefined, 'auth/setLoading'),
+      setAccessToken: (token) =>
+        set({ accessToken: token }, undefined, 'auth/setAccessToken'),
     }),
     { name: 'AuthStore' }
   )


### PR DESCRIPTION
## 관련 이슈

- closes #59

## 작업 내용

accessToken을 localStorage 대신 인메모리(authStore)에 저장하여 보안 강화
새로고침 시 me/refresh API로 새 accessToken 재발급하여 로그인 유지
refresh_token을 HttpOnly 쿠키로 관리
로그아웃 시 쿠키 삭제로 새로고침 시 로그인 안 되도록 처리
헤더 로딩 중 깜빡임 현상 개선

## 변경 사항

src/stores/authStore.ts — accessToken 상태 추가, localStorage 의존성 제거
src/providers/AuthProvider.tsx — localStorage 확인 대신 me/refresh 호출로 변경
src/pages/auth/LoginPage.tsx — localStorage 대신 authStore에 토큰 저장
src/pages/auth/SocialCallbackPage.tsx — localStorage 대신 authStore에 토큰 저장
src/api/interceptors.ts — localStorage 대신 authStore에서 토큰 가져오도록 변경, me/refresh 무한루프 방지
src/features/accounts/login/handler.ts — 로그인 성공 시 refresh_token 쿠키 설정
src/features/accounts/logout/handler.ts — 로그아웃 시 refresh_token 쿠키 삭제
src/features/accounts/social-login/handler.ts — me/refresh 목업 핸들러 추가, 쿠키 검증
src/features/accounts/social-login/queries.ts — withCredentials: true 추가
src/components/layout/Header/Header.tsx — isLoading 중 깜빡임 개선, 로그아웃 시 쿠키 직접 삭제
src/pages/auth/LoginPage.tsx — 소셜 로그인 시 쿠키 직접 설정 후 콜백 페이지로 이동

## 스크린샷 (선택)

## 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다
- [ ] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [ ] 컨벤션에 맞게 작성했습니다
