### PR TITLE
fix: Vercel 빌드 실패 수정 릴리즈 (#77)

### DIFF
--- a/src/features/exams/submission-detail/handler.ts
+++ b/src/features/exams/submission-detail/handler.ts
@@ -21,6 +21,7 @@ const mockSubmissionDetail: SubmissionDetailResponse = {
       options: ['O', 'X'],
       type: 'ox',
       answer: ['O'],
+      submitted_answer: ['O'],
       point: 10,
       explanation:
         'null == undefined는 동등 연산자(==)로 비교 시 true입니다. 단, null === undefined는 false입니다.',
@@ -34,6 +35,7 @@ const mockSubmissionDetail: SubmissionDetailResponse = {
       options: ['새로운 배열', '원본 배열', 'undefined', 'null'],
       type: 'single_choice',
       answer: ['새로운 배열'],
+      submitted_answer: ['원본 배열'],
       point: 10,
       explanation:
         'map()은 각 요소에 콜백을 적용한 결과로 구성된 새로운 배열을 반환합니다.',
@@ -48,6 +50,7 @@ const mockSubmissionDetail: SubmissionDetailResponse = {
       options: ['string', 'object', 'number', 'symbol', 'array'],
       type: 'multiple_choice',
       answer: ['string', 'number', 'symbol'],
+      submitted_answer: ['string', 'number', 'symbol'],
       point: 10,
       explanation:
         'JavaScript의 원시 타입은 string, number, bigint, boolean, undefined, symbol, null입니다. object와 array는 참조 타입입니다.',
@@ -61,6 +64,7 @@ const mockSubmissionDetail: SubmissionDetailResponse = {
       options: [],
       type: 'short_answer',
       answer: ['pending, fulfilled, rejected'],
+      submitted_answer: ['pending, fulfilled, rejected'],
       point: 10,
       explanation:
         'Promise는 pending(대기), fulfilled(이행), rejected(거부) 세 가지 상태를 가집니다.',
@@ -75,6 +79,7 @@ const mockSubmissionDetail: SubmissionDetailResponse = {
       options: [],
       type: 'fill_blank',
       answer: ['null', 'undefined'],
+      submitted_answer: ['undefined', 'null'],
       point: 10,
       explanation:
         'null은 의도적으로 값이 없음을 나타내고, undefined는 변수가 선언되었지만 값이 할당되지 않은 상태입니다.',
@@ -88,12 +93,20 @@ const mockSubmissionDetail: SubmissionDetailResponse = {
       options: ['콜백 등록', 'resolve 호출', 'Promise 생성', 'then 실행'],
       type: 'ordering',
       answer: ['Promise 생성', '콜백 등록', 'resolve 호출', 'then 실행'],
+      submitted_answer: ['Promise 생성', '콜백 등록', 'resolve 호출', 'then 실행'],
       point: 10,
       explanation:
         'Promise는 생성 → 콜백 등록 → resolve 호출 → then 실행 순서로 동작합니다.',
       is_correct: true,
     },
   ],
+  cheating_count: 1,
+  score: 40,
+  total_score: 60,
+  correct_answer_count: 4,
+  elapsed_time: 312,
+  started_at: '2026-05-11T05:00:00.000Z',
+  submitted_at: '2026-05-11T05:05:12.000Z',
 }
 
 export const submissionDetailHandlers = [
@@ -106,7 +119,7 @@ export const submissionDetailHandlers = [
     }
 
     // 404 테스트: submissionId=404 또는 NaN
-    if (submissionId === 404 || isNaN(submissionId)) {
+    if (submissionId === 404 || Number.isNaN(submissionId)) {
       return HttpResponse.json(
         { detail: '해당 시험 정보를 찾을 수 없습니다.' },
         { status: 404 }

--- a/src/features/exams/submission-detail/types.ts
+++ b/src/features/exams/submission-detail/types.ts
@@ -4,14 +4,23 @@ export interface SubmissionExam {
   thumbnail_img_url: string
 }
 
+export type QuestionType =
+  | 'ox'
+  | 'single_choice'
+  | 'multiple_choice'
+  | 'short_answer'
+  | 'ordering'
+  | 'fill_blank'
+
 export interface SubmissionQuestion {
   id: number
   question: string
   prompt: string
   blank_count: number
   options: string[]
-  type: string
+  type: QuestionType
   answer: string[]
+  submitted_answer: string[]
   point: number
   explanation: string
   is_correct: boolean
@@ -23,4 +32,11 @@ export interface SubmissionDetailResponse {
   deployment_id: number
   exam: SubmissionExam
   questions: SubmissionQuestion[]
+  cheating_count: number
+  score: number
+  total_score: number
+  correct_answer_count: number
+  elapsed_time: number
+  started_at: string
+  submitted_at: string
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,10 @@ import babel from '@rolldown/plugin-babel'
 import tailwindcss from '@tailwindcss/vite'
 import fs from 'fs'
 
+const pemKeyPath = path.resolve(__dirname, 'localhost-key.pem')
+const pemCertPath = path.resolve(__dirname, 'localhost.pem')
+const hasLocalPem = fs.existsSync(pemKeyPath) && fs.existsSync(pemCertPath)
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
@@ -17,10 +21,12 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
-  server: {
-    https: {
-      key: fs.readFileSync(path.resolve(__dirname, 'localhost-key.pem')),
-      cert: fs.readFileSync(path.resolve(__dirname, 'localhost.pem')),
-    },
-  },
+  server: hasLocalPem
+    ? {
+        https: {
+          key: fs.readFileSync(pemKeyPath),
+          cert: fs.readFileSync(pemCertPath),
+        },
+      }
+    : {},
 })


### PR DESCRIPTION
## 관련 이슈

- closes #77

## 작업 내용

- Vercel 빌드 환경에서 PEM 파일 부재로 인한 빌드 크래시 수정
- `submission-detail` 타입 누락 필드 보완

## 변경 사항

- `vite.config.ts` — PEM 파일 조건부 처리
- `src/features/exams/submission-detail/types.ts` — 타입 보완
- `src/features/exams/submission-detail/handler.ts` — mock 데이터 보완

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다