### PR TITLE
fix: 소셜 로그인시 로그인된 채 로그인 화면에 머무는 현상 수정(#81)

### DIFF
--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useNavigate, Link } from 'react-router'
 import { useQueryClient } from '@tanstack/react-query'
 import { Input } from '@/components/common/Input'
@@ -16,7 +16,7 @@ import logo from '@/assets/logo.png'
 export function LoginPage() {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const { login: setAuth } = useAuthStore()
+  const { login: setAuth, isAuthenticated, isLoading } = useAuthStore()
 
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
@@ -26,6 +26,12 @@ export function LoginPage() {
   const [isAlertOpen, setIsAlertOpen] = useState(false)
 
   const { mutate: login, isPending } = useLogin()
+
+  useEffect(() => {
+    if (!isLoading && isAuthenticated) {
+      navigate('/', { replace: true })
+    }
+  }, [isAuthenticated, isLoading, navigate])
 
   const handleSocialLogin = (provider: 'kakao' | 'naver') => {
     window.location.href = `${import.meta.env.VITE_API_BASE_URL}/accounts/social-login/${provider}`


### PR DESCRIPTION
- useEffect로 isAuthenticated + isLoading 상태를 감지
- 이미 인증된 상태로 LoginPage 진입 시 루트(/)로 즉시 리다이렉트

## 관련 이슈

- closes #81 

## 작업 내용

- 이미 로그인된 상태에서 로그인 페이지 접근 시 메인 페이지로 자동 이동 처리

## 변경 사항

- src/pages/auth/LoginPage.tsx — isAuthenticated 상태 감지 후 메인 페이지로 리다이렉트 로직 추가

## 스크린샷 (선택)

## 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다
- [ ] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [ ] 컨벤션에 맞게 작성했습니다
