### PR TITLE
refactor: accessToken 인메모리 -> 로컬스토리지(#84)

### DIFF
--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -23,7 +23,7 @@ export const useAuthStore = create<AuthState>()(
   devtools(
     (set) => ({
       isAuthenticated: !!localStorage.getItem('accessToken'),
-      isLoading: !!localStorage.getItem('accessToken'),
+      isLoading: true,
       accessToken: localStorage.getItem('accessToken'),
       user: null,
       login: (user, accessToken) => {

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -22,17 +22,20 @@ interface AuthState {
 export const useAuthStore = create<AuthState>()(
   devtools(
     (set) => ({
-      isAuthenticated: false,
-      isLoading: true,
-      accessToken: null,
+      isAuthenticated: !!localStorage.getItem('accessToken'),
+      isLoading: !!localStorage.getItem('accessToken'),
+      accessToken: localStorage.getItem('accessToken'),
       user: null,
-      login: (user, accessToken) =>
+      login: (user, accessToken) => {
+        localStorage.setItem('accessToken', accessToken)
         set(
           { isAuthenticated: true, isLoading: false, user, accessToken },
           undefined,
           'auth/login'
-        ),
-      logout: () =>
+        )
+      },
+      logout: () => {
+        localStorage.removeItem('accessToken')
         set(
           {
             isAuthenticated: false,
@@ -42,11 +45,14 @@ export const useAuthStore = create<AuthState>()(
           },
           undefined,
           'auth/logout'
-        ),
+        )
+      },
       setLoading: (loading) =>
         set({ isLoading: loading }, undefined, 'auth/setLoading'),
-      setAccessToken: (token) =>
-        set({ accessToken: token }, undefined, 'auth/setAccessToken'),
+      setAccessToken: (token) => {
+        localStorage.setItem('accessToken', token)
+        set({ accessToken: token }, undefined, 'auth/setAccessToken')
+      },
     }),
     { name: 'AuthStore' }
   )


### PR DESCRIPTION
- isAuthenticated, isLoading, accessToken 초기값을 localStorage 기반으로 설정
- login 시 localStorage에 accessToken 저장
- logout 시 localStorage에서 accessToken 제거
- setAccessToken 시 localStorage 동기화

## 관련 이슈

- closes #84 

## 작업 내용

- accessToken 인메모리 -> 로컬스토리지
## 변경 사항

- accessToken 인메모리 -> 로컬스토리지

## 스크린샷 (선택)

## 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다
- [ ] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [ ] 컨벤션에 맞게 작성했습니다
