### PR TITLE
chore: develop → main sync (PR #85까지)

### DIFF
--- a/docs/convention/PAGES.md
+++ b/docs/convention/PAGES.md
@@ -51,11 +51,11 @@ src/pages/
 
 ### quiz/
 
-| 파일               | 라우트                 | 설명                  |
-| ------------------ | ---------------------- | --------------------- |
-| QuizListPage.tsx   | `/mypage/quiz`         | 쪽지시험 목록         |
-| QuizExamPage.tsx   | `/quiz/:quizId/exam`   | 시험 응시 (문제 풀이) |
-| QuizResultPage.tsx | `/quiz/:quizId/result` | 결과 확인             |
+| 파일               | 라우트                       | 설명                  |
+| ------------------ | ---------------------------- | --------------------- |
+| QuizListPage.tsx   | `/mypage/quiz`               | 쪽지시험 목록         |
+| QuizExamPage.tsx   | `/quiz/:quizId/exam`         | 시험 응시 (문제 풀이) |
+| QuizResultPage.tsx | `/quiz/:submissionId/result` | 결과 확인             |
 
 참가코드 입력, 제출 완료 안내는 모달로 처리
 

--- a/src/components/quiz/list/QuizCard/QuizCard.tsx
+++ b/src/components/quiz/list/QuizCard/QuizCard.tsx
@@ -10,7 +10,10 @@ interface QuizCardProps {
   item: DeploymentListItem
 }
 
-type QuizCardAction = { type: 'navigate'; path: string } | { type: 'openModal' }
+type QuizCardAction =
+  | { type: 'navigate'; path: string }
+  | { type: 'openModal' }
+  | { type: 'disabled' }
 
 interface QuizCardViewModel {
   badgeLabel: string
@@ -21,7 +24,14 @@ interface QuizCardViewModel {
 }
 
 function getQuizCardViewModel(item: DeploymentListItem): QuizCardViewModel {
-  const { id, exam, exam_info, question_count, total_score, is_done } = item
+  const {
+    exam,
+    exam_info,
+    question_count,
+    total_score,
+    is_done,
+    submission_id,
+  } = item
 
   if (is_done) {
     return {
@@ -29,10 +39,16 @@ function getQuizCardViewModel(item: DeploymentListItem): QuizCardViewModel {
       badgeClassName: 'bg-success-bg text-success-dark',
       subtitle: `${exam.subject.title} · ${exam_info.score ?? 0}점/${total_score}점 · ${exam_info.correct_answer_count ?? 0}/${question_count}개 정답`,
       buttonLabel: '상세보기',
-      action: {
-        type: 'navigate',
-        path: ROUTES.QUIZ.RESULT.replace(':quizId', String(id)),
-      },
+      action:
+        submission_id != null
+          ? {
+              type: 'navigate',
+              path: ROUTES.QUIZ.RESULT.replace(
+                ':submissionId',
+                String(submission_id)
+              ),
+            }
+          : { type: 'disabled' },
     }
   }
 
@@ -74,7 +90,7 @@ export function QuizCard({ item }: QuizCardProps) {
   const handleButtonClick = () => {
     if (vm.action.type === 'navigate') {
       navigate(vm.action.path)
-    } else {
+    } else if (vm.action.type === 'openModal') {
       setIsModalOpen(true)
     }
   }
@@ -102,6 +118,7 @@ export function QuizCard({ item }: QuizCardProps) {
         variant="outline"
         size="md"
         className="w-[112px]"
+        disabled={vm.action.type === 'disabled'}
         onClick={handleButtonClick}
       >
         {vm.buttonLabel}

--- a/src/components/quiz/result/QuizResultContent/QuizResultContent.tsx
+++ b/src/components/quiz/result/QuizResultContent/QuizResultContent.tsx
@@ -1,0 +1,62 @@
+import { useNavigate } from 'react-router'
+import { Button } from '@/components/common/Button'
+import { useSubmissionDetail } from '@/features/exams/submission-detail'
+import { ROUTES } from '@/constants/routes'
+import { ResultQuestionCard } from '@/components/quiz/result/ResultQuestionCard'
+import { ResultHeader } from '@/components/quiz/result/ResultHeader'
+
+interface QuizResultContentProps {
+  submissionId: number
+}
+
+export function QuizResultContent({ submissionId }: QuizResultContentProps) {
+  const navigate = useNavigate()
+  const { data } = useSubmissionDetail(submissionId)
+  const { exam, questions, cheating_count, score, total_score, elapsed_time } =
+    data
+
+  return (
+    <div className="min-h-screen bg-white">
+      <ResultHeader
+        examTitle={exam.title}
+        totalQuestions={questions.length}
+        cheatingCount={cheating_count}
+        elapsedTime={elapsed_time}
+        score={score}
+        totalScore={total_score}
+        onBack={() => navigate(ROUTES.MYPAGE.QUIZ)}
+      />
+
+      <div className="bg-primary-100">
+        <div className="max-w-container mx-auto px-6 py-8">
+          <h1 className="text-2xl font-bold tracking-[-0.03em] text-gray-900">
+            쪽지시험 응시 결과
+          </h1>
+          <p className="mt-2 text-sm leading-[140%] tracking-[-0.03em] text-gray-600">
+            고생 많으셨어요😊 틀린 문제는 해설을 보며 꼭 복습해보세요. 앞으로의
+            성장을 기대하겠습니다!
+          </p>
+        </div>
+      </div>
+
+      <main className="max-w-container mx-auto px-6 py-10">
+        <div className="flex flex-col gap-[100px]">
+          {questions.map((q, i) => (
+            <ResultQuestionCard key={q.id} question={q} index={i} />
+          ))}
+        </div>
+
+        <div className="mt-12 flex justify-center">
+          <Button
+            variant="primary"
+            size="md"
+            className="px-12"
+            onClick={() => navigate(ROUTES.MYPAGE.QUIZ)}
+          >
+            완료
+          </Button>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/src/components/quiz/result/QuizResultContent/index.ts
+++ b/src/components/quiz/result/QuizResultContent/index.ts
@@ -1,0 +1,1 @@
+export { QuizResultContent } from './QuizResultContent'

--- a/src/components/quiz/result/QuizResultErrorBoundary/QuizResultErrorBoundary.tsx
+++ b/src/components/quiz/result/QuizResultErrorBoundary/QuizResultErrorBoundary.tsx
@@ -1,0 +1,48 @@
+import { ErrorBoundary } from 'react-error-boundary'
+import { ErrorFallback } from '@/components/common/ErrorFallback'
+import { HTTP_STATUS } from '@/constants/httpStatus'
+import { useToastStore } from '@/stores/toastStore'
+import { getErrorStatus } from '@/utils/getErrorStatus'
+
+const ERROR_MESSAGES: Record<number, string> = {
+  [HTTP_STATUS.FORBIDDEN]: '결과를 조회할 권한이 없습니다.',
+  [HTTP_STATUS.NOT_FOUND]: '해당 시험 결과를 찾을 수 없습니다.',
+}
+
+function handleError(error: unknown) {
+  const status = getErrorStatus(error)
+  if (!status || status >= HTTP_STATUS.INTERNAL_SERVER_ERROR) {
+    useToastStore
+      .getState()
+      .show('일시적인 오류가 발생했습니다. 다시 시도해주세요.', 'error')
+  }
+}
+
+export function QuizResultErrorBoundary({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <ErrorBoundary
+      fallbackRender={({ error, resetErrorBoundary }) => {
+        const status = getErrorStatus(error)
+        return (
+          <ErrorFallback
+            message={
+              ERROR_MESSAGES[status ?? 0] ?? '알 수 없는 오류가 발생했습니다.'
+            }
+            onRetry={
+              !status || status >= HTTP_STATUS.INTERNAL_SERVER_ERROR
+                ? resetErrorBoundary
+                : undefined
+            }
+          />
+        )
+      }}
+      onError={handleError}
+    >
+      {children}
+    </ErrorBoundary>
+  )
+}

--- a/src/components/quiz/result/QuizResultErrorBoundary/index.ts
+++ b/src/components/quiz/result/QuizResultErrorBoundary/index.ts
@@ -1,0 +1,1 @@
+export { QuizResultErrorBoundary } from './QuizResultErrorBoundary'

--- a/src/components/quiz/result/ResultHeader/ResultHeader.tsx
+++ b/src/components/quiz/result/ResultHeader/ResultHeader.tsx
@@ -1,0 +1,51 @@
+import { ArrowLeft } from 'lucide-react'
+
+interface ResultHeaderProps {
+  examTitle: string
+  totalQuestions: number
+  cheatingCount: number
+  elapsedTime: number
+  score: number
+  totalScore: number
+  onBack: () => void
+}
+
+export function ResultHeader({
+  examTitle,
+  totalQuestions,
+  cheatingCount,
+  elapsedTime,
+  score,
+  totalScore,
+  onBack,
+}: ResultHeaderProps) {
+  const statsText = [
+    `총 문항 수: ${totalQuestions}`,
+    `부정행위: ${cheatingCount}회`,
+    `응시시간: ${elapsedTime}분`,
+    `응시 결과 점수: ${score}점/${totalScore}점`,
+  ].join(' ㆍ ')
+
+  return (
+    <header className="sticky top-0 z-40 border-b border-gray-200 bg-white">
+      <div className="max-w-container mx-auto flex h-[127px] flex-col justify-center gap-2 px-6">
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={onBack}
+            aria-label="시험 목록으로 돌아가기"
+            className="focus-visible:ring-primary shrink-0 rounded text-gray-900 focus-visible:ring-2 focus-visible:ring-offset-2"
+          >
+            <ArrowLeft size={24} aria-hidden="true" />
+          </button>
+          <span className="text-xl leading-[140%] font-semibold tracking-[-0.03em] text-gray-900">
+            {examTitle}
+          </span>
+        </div>
+        <p className="pl-9 text-base leading-[140%] tracking-[-0.03em] text-gray-600">
+          {statsText}
+        </p>
+      </div>
+    </header>
+  )
+}

--- a/src/components/quiz/result/ResultHeader/index.ts
+++ b/src/components/quiz/result/ResultHeader/index.ts
@@ -1,0 +1,1 @@
+export { ResultHeader } from './ResultHeader'

--- a/src/components/quiz/result/ResultQuestionCard/ResultQuestionCard.tsx
+++ b/src/components/quiz/result/ResultQuestionCard/ResultQuestionCard.tsx
@@ -1,0 +1,142 @@
+import { Circle, X } from 'lucide-react'
+import type { SubmissionQuestion } from '@/features/exams/submission-detail'
+import { OXResult } from './questions/OXResult'
+import { ChoiceResult } from './questions/ChoiceResult'
+import { ShortAnswerResult } from './questions/ShortAnswerResult'
+import { FillBlankResult } from './questions/FillBlankResult'
+import { OrderingResult } from './questions/OrderingResult'
+
+const TYPE_LABELS: Record<SubmissionQuestion['type'], string> = {
+  ox: 'OX선택',
+  single_choice: '단일선택',
+  multiple_choice: '다중선택',
+  short_answer: '단답형',
+  ordering: '순서배열',
+  fill_blank: '빈칸식',
+}
+
+interface ResultQuestionCardProps {
+  question: SubmissionQuestion
+  index: number
+}
+
+export function ResultQuestionCard({
+  question,
+  index,
+}: ResultQuestionCardProps) {
+  const {
+    question: text,
+    answer,
+    submitted_answer,
+    point,
+    explanation,
+    is_correct,
+  } = question
+
+  const renderAnswerView = () => {
+    switch (question.type) {
+      case 'ox':
+        return (
+          <OXResult
+            answer={question.answer}
+            submittedAnswer={question.submitted_answer}
+          />
+        )
+      case 'single_choice':
+        return (
+          <ChoiceResult
+            options={question.options}
+            answer={answer}
+            submittedAnswer={submitted_answer}
+            multi={false}
+          />
+        )
+      case 'multiple_choice':
+        return (
+          <ChoiceResult
+            options={question.options}
+            answer={answer}
+            submittedAnswer={submitted_answer}
+            multi={true}
+          />
+        )
+      case 'short_answer':
+        return (
+          <ShortAnswerResult
+            submittedAnswer={submitted_answer}
+            isCorrect={is_correct}
+          />
+        )
+      case 'fill_blank':
+        return (
+          <FillBlankResult
+            prompt={question.prompt}
+            blankCount={question.blank_count}
+            answer={answer}
+            submittedAnswer={submitted_answer}
+          />
+        )
+      case 'ordering':
+        return (
+          <OrderingResult
+            options={question.options}
+            answer={answer}
+            submittedAnswer={submitted_answer}
+          />
+        )
+    }
+  }
+
+  return (
+    <article className="flex flex-col gap-5">
+      {/* 질문 헤더 */}
+      <div className="flex items-baseline py-1">
+        <span className="w-8 shrink-0 text-xl leading-[140%] font-bold tracking-[-0.03em] text-gray-900">
+          {index + 1}.
+        </span>
+        <h2 className="text-xl leading-[140%] font-bold tracking-[-0.03em] text-gray-900">
+          {text}
+          <span className="relative -top-0.5 ml-4 inline-flex items-center gap-2 align-top">
+            <span className="bg-disable rounded-sm px-3 py-2 text-xs leading-[140%] tracking-[-0.03em] whitespace-nowrap text-gray-900">
+              {point}점
+            </span>
+            <span className="bg-disable rounded-sm px-3 py-2 text-xs leading-[140%] tracking-[-0.03em] whitespace-nowrap text-gray-900">
+              {TYPE_LABELS[question.type]}
+            </span>
+          </span>
+        </h2>
+      </div>
+
+      {/* 답안 영역 — 번호(w-8=32px)만큼 들여쓰기해 텍스트 시작점과 일치 */}
+      <div className="pl-8">{renderAnswerView()}</div>
+
+      {/* 해설 */}
+      {explanation && (
+        <div className="pl-8">
+          <div
+            className={`flex items-center gap-3 rounded px-4 py-6 ${is_correct ? 'bg-success-bg' : 'bg-error-bg'}`}
+          >
+            {is_correct ? (
+              <Circle
+                size={20}
+                strokeWidth={2}
+                className="text-success-dark shrink-0"
+                aria-hidden="true"
+              />
+            ) : (
+              <X
+                size={20}
+                strokeWidth={3}
+                className="text-error shrink-0"
+                aria-hidden="true"
+              />
+            )}
+            <p className="text-base leading-[140%] tracking-[-0.03em] text-black">
+              {explanation}
+            </p>
+          </div>
+        </div>
+      )}
+    </article>
+  )
+}

--- a/src/components/quiz/result/ResultQuestionCard/index.ts
+++ b/src/components/quiz/result/ResultQuestionCard/index.ts
@@ -1,0 +1,1 @@
+export { ResultQuestionCard } from './ResultQuestionCard'

--- a/src/components/quiz/result/ResultQuestionCard/questions/ChoiceResult.tsx
+++ b/src/components/quiz/result/ResultQuestionCard/questions/ChoiceResult.tsx
@@ -1,0 +1,68 @@
+import { Check } from 'lucide-react'
+
+function getChoiceTextColor(isCorrect: boolean, isSubmitted: boolean): string {
+  if (isCorrect) return 'text-success-dark'
+  if (isSubmitted) return 'text-error'
+  return 'text-gray-800'
+}
+
+export function ChoiceResult({
+  options,
+  answer,
+  submittedAnswer,
+  multi,
+}: {
+  options: string[]
+  answer: string[]
+  submittedAnswer: string[]
+  multi: boolean
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      {options.map((option, i) => {
+        const isSubmitted = submittedAnswer.includes(option)
+        const isCorrect = answer.includes(option)
+        const textColor = getChoiceTextColor(isCorrect, isSubmitted)
+
+        return (
+          <div key={`${i}-${option}`} className="flex items-center gap-3">
+            {multi ? (
+              <span
+                className={[
+                  'flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-sm border transition-colors',
+                  isSubmitted
+                    ? 'border-primary bg-primary'
+                    : 'border-gray-350 bg-white',
+                ].join(' ')}
+                aria-hidden="true"
+              >
+                {isSubmitted && (
+                  <Check size={10} strokeWidth={1.5} className="text-white" />
+                )}
+              </span>
+            ) : (
+              <span
+                className={[
+                  'flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full border-2 transition-colors',
+                  isSubmitted
+                    ? 'border-primary bg-primary'
+                    : 'border-gray-350 bg-white',
+                ].join(' ')}
+                aria-hidden="true"
+              >
+                {isSubmitted && (
+                  <span className="h-2 w-2 rounded-full bg-white" />
+                )}
+              </span>
+            )}
+            <span
+              className={`text-base leading-[140%] tracking-[-0.03em] ${textColor}`}
+            >
+              {option}
+            </span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/quiz/result/ResultQuestionCard/questions/FillBlankResult.tsx
+++ b/src/components/quiz/result/ResultQuestionCard/questions/FillBlankResult.tsx
@@ -1,0 +1,63 @@
+import { indexToLetter } from '@/utils/indexToLetter'
+
+export function FillBlankResult({
+  prompt,
+  blankCount,
+  answer,
+  submittedAnswer,
+}: {
+  prompt: string
+  blankCount: number
+  answer: string[]
+  submittedAnswer: string[]
+}) {
+  const segments = prompt.split('[blank]')
+
+  return (
+    <div className="flex max-w-[648px] flex-col gap-4">
+      {/* 지문 박스 */}
+      <div className="bg-bg-prompt rounded px-4 py-5">
+        <p className="text-base leading-[140%] tracking-[-0.03em] whitespace-pre-wrap text-gray-800">
+          {segments.map((segment, i) => (
+            <span key={`${i}-${segment}`}>
+              {segment}
+              {i < segments.length - 1 && (
+                <span className="font-semibold text-gray-800">
+                  ({indexToLetter(i)}) ______
+                </span>
+              )}
+            </span>
+          ))}
+        </p>
+      </div>
+
+      {/* 답안 입력칸 표시 */}
+      <div className="flex flex-col gap-2">
+        {Array.from({ length: blankCount }).map((_, i) => {
+          const submitted = submittedAnswer[i] ?? ''
+          const correctAns = answer[i] ?? ''
+          const isCorrectBlank = submitted === correctAns
+          const textColor = isCorrectBlank ? 'text-success-dark' : 'text-error'
+
+          return (
+            <div
+              key={`${i}-${submitted}`}
+              className="bg-bg-muted flex h-12 w-[308px] items-center gap-2 rounded px-4"
+            >
+              <span
+                className={`text-lg font-semibold tracking-[-0.03em] ${textColor}`}
+              >
+                {indexToLetter(i)}
+              </span>
+              <span
+                className={`text-base leading-[140%] tracking-[-0.03em] ${textColor}`}
+              >
+                {submitted || '(미입력)'}
+              </span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/quiz/result/ResultQuestionCard/questions/OXResult.tsx
+++ b/src/components/quiz/result/ResultQuestionCard/questions/OXResult.tsx
@@ -1,0 +1,73 @@
+import { Check, Circle, X } from 'lucide-react'
+
+const OX_OPTIONS = [
+  { value: 'O', label: '맞아요' },
+  { value: 'X', label: '아니에요' },
+] as const
+
+function getOXContainerColor(
+  isAnswer: boolean,
+  isWrongSubmit: boolean
+): string {
+  if (isAnswer) return 'bg-success-bg'
+  if (isWrongSubmit) return 'bg-error-bg'
+  return 'bg-bg-muted'
+}
+
+function getOXTextColor(isAnswer: boolean, isWrongSubmit: boolean): string {
+  if (isAnswer) return 'text-success-dark'
+  if (isWrongSubmit) return 'text-error'
+  return 'text-gray-600'
+}
+
+export function OXResult({
+  answer,
+  submittedAnswer,
+}: {
+  answer: ('O' | 'X')[]
+  submittedAnswer: ('O' | 'X')[]
+}) {
+  return (
+    <div className="flex max-w-[308px] flex-col gap-3">
+      {OX_OPTIONS.map(({ value, label }) => {
+        const isAnswer = answer.includes(value)
+        const isSubmitted = submittedAnswer.includes(value)
+        const isWrongSubmit = isSubmitted && !isAnswer
+
+        const container = getOXContainerColor(isAnswer, isWrongSubmit)
+        const text = getOXTextColor(isAnswer, isWrongSubmit)
+
+        return (
+          <div
+            key={value}
+            className={`flex h-12 items-center gap-2 rounded px-4 ${container}`}
+          >
+            <span
+              className={`flex w-5 shrink-0 items-center justify-center ${text}`}
+              aria-hidden="true"
+            >
+              {value === 'O' ? (
+                <Circle size={20} strokeWidth={2} />
+              ) : (
+                <X size={20} strokeWidth={2.5} />
+              )}
+            </span>
+            <span
+              className={`flex-1 text-base leading-[140%] tracking-[-0.03em] ${text}`}
+            >
+              {label}
+            </span>
+            {isSubmitted && (
+              <Check
+                size={18}
+                strokeWidth={2}
+                className={isAnswer ? 'text-success-dark' : 'text-error'}
+                aria-hidden="true"
+              />
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/quiz/result/ResultQuestionCard/questions/OrderingResult.tsx
+++ b/src/components/quiz/result/ResultQuestionCard/questions/OrderingResult.tsx
@@ -1,0 +1,46 @@
+import { indexToLetter } from '@/utils/indexToLetter'
+
+export function OrderingResult({
+  options,
+  answer,
+  submittedAnswer,
+}: {
+  options: string[]
+  answer: string[]
+  submittedAnswer: string[]
+}) {
+  return (
+    <div className="flex max-w-[648px] flex-col gap-4">
+      {/* 선택지 목록 */}
+      <div className="bg-bg-prompt flex flex-col gap-5 rounded px-4 py-5">
+        {options.map((option, i) => (
+          <div key={`${i}-${option}`} className="flex items-center gap-2">
+            <span className="bg-primary-100 text-primary flex h-8 w-8 shrink-0 items-center justify-center rounded text-lg font-normal tracking-[-0.03em]">
+              {indexToLetter(i)}
+            </span>
+            <span className="text-base leading-[140%] tracking-[-0.03em] text-gray-800">
+              {option}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* 제출된 순서 슬롯: 정답과 일치 여부에 따라 색상 표시 */}
+      <div className="flex flex-wrap gap-[10px]">
+        {submittedAnswer.map((item, i) => {
+          const isCorrectPos = item === answer[i]
+          const letterIdx = options.indexOf(item)
+          const letter = letterIdx >= 0 ? indexToLetter(letterIdx) : '?'
+          return (
+            <div
+              key={`${i}-${item}`}
+              className={`bg-disable flex h-[62px] w-[62px] items-center justify-center rounded text-xl font-bold tracking-[-0.03em] ${isCorrectPos ? 'text-success-dark' : 'text-error'}`}
+            >
+              {letter}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/quiz/result/ResultQuestionCard/questions/ShortAnswerResult.tsx
+++ b/src/components/quiz/result/ResultQuestionCard/questions/ShortAnswerResult.tsx
@@ -1,0 +1,19 @@
+export function ShortAnswerResult({
+  submittedAnswer,
+  isCorrect,
+}: {
+  submittedAnswer: string[]
+  isCorrect: boolean
+}) {
+  return (
+    <div className="flex max-w-[648px] flex-col gap-2">
+      <div className="bg-bg-muted flex h-12 max-w-[648px] items-center rounded px-4">
+        <span
+          className={`text-base leading-[140%] tracking-[-0.03em] ${isCorrect ? 'text-success-dark' : 'text-error'}`}
+        >
+          {submittedAnswer[0] || '(미입력)'}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -19,7 +19,7 @@ export const ROUTES = {
 
   QUIZ: {
     EXAM: '/quiz/:quizId/exam',
-    RESULT: '/quiz/:quizId/result',
+    RESULT: '/quiz/:submissionId/result',
   },
 
   QNA: {

--- a/src/features/exams/submission-detail/handler.ts
+++ b/src/features/exams/submission-detail/handler.ts
@@ -16,8 +16,8 @@ const mockSubmissionDetail: SubmissionDetailResponse = {
     {
       id: 1,
       question: 'JavaScript에서 null == undefined는 true이다.',
-      prompt: '',
-      blank_count: 0,
+      prompt: null,
+      blank_count: null,
       options: ['O', 'X'],
       type: 'ox',
       answer: ['O'],
@@ -30,8 +30,8 @@ const mockSubmissionDetail: SubmissionDetailResponse = {
     {
       id: 2,
       question: 'Array.prototype.map()의 반환값은 무엇인가?',
-      prompt: '',
-      blank_count: 0,
+      prompt: null,
+      blank_count: null,
       options: ['새로운 배열', '원본 배열', 'undefined', 'null'],
       type: 'single_choice',
       answer: ['새로운 배열'],
@@ -45,8 +45,8 @@ const mockSubmissionDetail: SubmissionDetailResponse = {
       id: 3,
       question:
         '다음 중 JavaScript의 원시 타입(Primitive type)에 해당하는 것을 모두 고르시오.',
-      prompt: '',
-      blank_count: 0,
+      prompt: null,
+      blank_count: null,
       options: ['string', 'object', 'number', 'symbol', 'array'],
       type: 'multiple_choice',
       answer: ['string', 'number', 'symbol'],
@@ -59,9 +59,9 @@ const mockSubmissionDetail: SubmissionDetailResponse = {
     {
       id: 4,
       question: 'Promise의 세 가지 상태를 쉼표로 구분하여 적으시오.',
-      prompt: '',
-      blank_count: 0,
-      options: [],
+      prompt: null,
+      blank_count: null,
+      options: null,
       type: 'short_answer',
       answer: ['pending, fulfilled, rejected'],
       submitted_answer: ['pending, fulfilled, rejected'],
@@ -76,7 +76,7 @@ const mockSubmissionDetail: SubmissionDetailResponse = {
       prompt:
         '자바스크립트에서 [blank]는 값이 없음을 의미하고, [blank]는 존재하지 않음을 의미한다.',
       blank_count: 2,
-      options: [],
+      options: null,
       type: 'fill_blank',
       answer: ['null', 'undefined'],
       submitted_answer: ['undefined', 'null'],
@@ -88,12 +88,17 @@ const mockSubmissionDetail: SubmissionDetailResponse = {
     {
       id: 6,
       question: '다음 Promise 실행 순서를 올바르게 배열하시오.',
-      prompt: '',
-      blank_count: 0,
+      prompt: null,
+      blank_count: null,
       options: ['콜백 등록', 'resolve 호출', 'Promise 생성', 'then 실행'],
       type: 'ordering',
       answer: ['Promise 생성', '콜백 등록', 'resolve 호출', 'then 실행'],
-      submitted_answer: ['Promise 생성', '콜백 등록', 'resolve 호출', 'then 실행'],
+      submitted_answer: [
+        'Promise 생성',
+        '콜백 등록',
+        'resolve 호출',
+        'then 실행',
+      ],
       point: 10,
       explanation:
         'Promise는 생성 → 콜백 등록 → resolve 호출 → then 실행 순서로 동작합니다.',
@@ -104,9 +109,9 @@ const mockSubmissionDetail: SubmissionDetailResponse = {
   score: 40,
   total_score: 60,
   correct_answer_count: 4,
-  elapsed_time: 312,
+  elapsed_time: 15,
   started_at: '2026-05-11T05:00:00.000Z',
-  submitted_at: '2026-05-11T05:05:12.000Z',
+  submitted_at: '2026-05-11T05:15:00.000Z',
 }
 
 export const submissionDetailHandlers = [
@@ -115,13 +120,16 @@ export const submissionDetailHandlers = [
 
     // 403 테스트: submissionId=403
     if (submissionId === 403) {
-      return HttpResponse.json({ detail: '권한이 없습니다.' }, { status: 403 })
+      return HttpResponse.json(
+        { error_detail: '권한이 없습니다.' },
+        { status: 403 }
+      )
     }
 
     // 404 테스트: submissionId=404 또는 NaN
     if (submissionId === 404 || Number.isNaN(submissionId)) {
       return HttpResponse.json(
-        { detail: '해당 시험 정보를 찾을 수 없습니다.' },
+        { error_detail: '해당 시험 정보를 찾을 수 없습니다.' },
         { status: 404 }
       )
     }

--- a/src/features/exams/submission-detail/types.ts
+++ b/src/features/exams/submission-detail/types.ts
@@ -1,7 +1,7 @@
 export interface SubmissionExam {
   id: number
   title: string
-  thumbnail_img_url: string
+  thumbnail_img_url: string | null
 }
 
 export type QuestionType =
@@ -12,19 +12,55 @@ export type QuestionType =
   | 'ordering'
   | 'fill_blank'
 
-export interface SubmissionQuestion {
+type BaseQuestion = {
   id: number
   question: string
-  prompt: string
-  blank_count: number
-  options: string[]
-  type: QuestionType
   answer: string[]
   submitted_answer: string[]
   point: number
   explanation: string
   is_correct: boolean
 }
+
+// OX: answer/submitted_answer 값이 'O' | 'X'로 고정
+type OXQuestion = Omit<BaseQuestion, 'answer' | 'submitted_answer'> & {
+  type: 'ox'
+  options: ('O' | 'X')[]
+  answer: ('O' | 'X')[]
+  submitted_answer: ('O' | 'X')[]
+  prompt: null
+  blank_count: null
+}
+
+// 단일선택 · 다중선택 · 순서배열: options 있음, prompt/blank_count는 null
+type OptionsQuestion = BaseQuestion & {
+  type: 'single_choice' | 'multiple_choice' | 'ordering'
+  options: string[]
+  prompt: null
+  blank_count: null
+}
+
+// 단답형: options/prompt/blank_count 모두 null
+type ShortAnswerQuestion = BaseQuestion & {
+  type: 'short_answer'
+  options: null
+  prompt: null
+  blank_count: null
+}
+
+// 빈칸식: prompt · blank_count 있음, options는 null
+type FillBlankQuestion = BaseQuestion & {
+  type: 'fill_blank'
+  options: null
+  prompt: string
+  blank_count: number
+}
+
+export type SubmissionQuestion =
+  | OXQuestion
+  | OptionsQuestion
+  | ShortAnswerQuestion
+  | FillBlankQuestion
 
 export interface SubmissionDetailResponse {
   id: number

--- a/src/features/exams/submissions/handler.ts
+++ b/src/features/exams/submissions/handler.ts
@@ -62,7 +62,7 @@ export const submissionsHandlers = [
         submission_id: 1001,
         score: 80,
         correct_answer_count: 5,
-        redirect_url: `/quiz/${body.deployment_id ?? 2}/result`,
+        redirect_url: `/quiz/1001/result`,
       },
       { status: HTTP_STATUS.CREATED }
     )

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,14 +1,14 @@
 import { http, HttpResponse } from 'msw'
 import { deploymentsHandlers } from '@/features/exams/deployments'
-// import { meHandlers } from '@/features/accounts/me'
-// import { meEnrolledCoursesHandlers } from '@/features/accounts/me-enrolled-courses'
+import { meHandlers } from '@/features/accounts/me'
+import { meEnrolledCoursesHandlers } from '@/features/accounts/me-enrolled-courses'
 import { checkCodeHandlers } from '@/features/exams/deployment-check-code'
-// import { checkNicknameHandlers } from '@/features/accounts/check-nickname'
+import { checkNicknameHandlers } from '@/features/accounts/check-nickname'
 import { meProfileImageHandlers } from '@/features/accounts/me-profile-image'
 import { deploymentDetailHandlers } from '@/features/exams/deployment-detail'
 import { deploymentStatusHandlers } from '@/features/exams/deployment-status'
 import { submissionsHandlers } from '@/features/exams/submissions'
-// import { logoutHandlers } from '@/features/accounts/logout'
+import { logoutHandlers } from '@/features/accounts/logout'
 import { courseListHandlers } from '@/features/course/list/handler'
 import { cohortHandlers } from '@/features/course/cohorts/handler'
 import { enrollStudentHandlers } from '@/features/accounts/enroll-student/handler'
@@ -21,17 +21,17 @@ export const handlers = [
   http.get('/api/health', () => {
     return HttpResponse.json({ status: 'ok' })
   }),
-  // ...meHandlers,
-  // ...meEnrolledCoursesHandlers,
+  ...meHandlers,
+  ...meEnrolledCoursesHandlers,
   ...deploymentsHandlers,
   // status / check-code는 deploymentDetail보다 먼저 등록해 패스 우선순위 확보
   ...deploymentStatusHandlers,
   ...checkCodeHandlers,
-  // ...checkNicknameHandlers,
+  ...checkNicknameHandlers,
   ...meProfileImageHandlers,
   ...deploymentDetailHandlers,
   ...submissionsHandlers,
-  // ...logoutHandlers,
+  ...logoutHandlers,
   ...courseListHandlers,
   ...cohortHandlers,
   ...enrollStudentHandlers,

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useNavigate, Link } from 'react-router'
 import { useQueryClient } from '@tanstack/react-query'
 import { Input } from '@/components/common/Input'
@@ -16,7 +16,7 @@ import logo from '@/assets/logo.png'
 export function LoginPage() {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const { login: setAuth } = useAuthStore()
+  const { login: setAuth, isAuthenticated, isLoading } = useAuthStore()
 
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
@@ -26,6 +26,12 @@ export function LoginPage() {
   const [isAlertOpen, setIsAlertOpen] = useState(false)
 
   const { mutate: login, isPending } = useLogin()
+
+  useEffect(() => {
+    if (!isLoading && isAuthenticated) {
+      navigate('/', { replace: true })
+    }
+  }, [isAuthenticated, isLoading, navigate])
 
   const handleSocialLogin = (provider: 'kakao' | 'naver') => {
     window.location.href = `${import.meta.env.VITE_API_BASE_URL}/accounts/social-login/${provider}`

--- a/src/pages/quiz/QuizExamPage.tsx
+++ b/src/pages/quiz/QuizExamPage.tsx
@@ -4,9 +4,6 @@ import { Spinner } from '@/components/common/Spinner'
 import { ExamContent } from './exam/ExamContent'
 import { ROUTES } from '@/constants/routes'
 
-/**
- * @figma 쪽지시험_응시하기  https://www.figma.com/design/zTej1hAEgfChWzZhByThtt/%EC%9D%B5%EC%8A%A4%ED%84%B4%EC%8B%AD-%EC%AA%BD%EC%A7%80%EC%8B%9C%ED%97%98?node-id=1-710
- */
 export function QuizExamPage() {
   const { quizId } = useParams<{ quizId: string }>()
   const location = useLocation()

--- a/src/pages/quiz/QuizResultPage.tsx
+++ b/src/pages/quiz/QuizResultPage.tsx
@@ -1,6 +1,31 @@
-/**
- * @figma 쪽지시험_결과확인  https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-4815&m=dev
- */
+import { Suspense } from 'react'
+import { useParams, Navigate } from 'react-router'
+import { Spinner } from '@/components/common/Spinner'
+import { ROUTES } from '@/constants/routes'
+import { QuizResultErrorBoundary } from '@/components/quiz/result/QuizResultErrorBoundary'
+import { QuizResultContent } from '@/components/quiz/result/QuizResultContent'
+
 export function QuizResultPage() {
-  return <div>쪽지시험 - 결과 확인</div>
+  const { submissionId: submissionIdParam } = useParams<{
+    submissionId?: string
+  }>()
+  const submissionId = Number(submissionIdParam)
+
+  if (!Number.isInteger(submissionId) || submissionId <= 0) {
+    return <Navigate to={ROUTES.MYPAGE.QUIZ} replace />
+  }
+
+  return (
+    <QuizResultErrorBoundary>
+      <Suspense
+        fallback={
+          <div className="flex min-h-screen items-center justify-center bg-white">
+            <Spinner />
+          </div>
+        }
+      >
+        <QuizResultContent submissionId={submissionId} />
+      </Suspense>
+    </QuizResultErrorBoundary>
+  )
 }

--- a/src/pages/quiz/exam/hooks/useExamSubmission.ts
+++ b/src/pages/quiz/exam/hooks/useExamSubmission.ts
@@ -94,12 +94,25 @@ export function useExamSubmission({
         },
         {
           onSuccess: (res) => {
+            if (res.submission_id == null) {
+              showToast(
+                '제출 결과를 불러올 수 없습니다. 다시 시도해주세요.',
+                'error'
+              )
+              isSubmittingRef.current = false
+              setIsSubmitted(false)
+              return
+            }
+            const resultUrl = ROUTES.QUIZ.RESULT.replace(
+              ':submissionId',
+              String(res.submission_id)
+            )
             if (reason === 'button') {
               // 버튼 제출: 완료 모달을 표시하고 수험자 확인 후 이동
-              setSubmitRedirectUrl(res.redirect_url)
+              setSubmitRedirectUrl(resultUrl)
             } else {
               // 타이머/부정행위: 모달 없이 바로 결과 페이지로 이동
-              navigate(res.redirect_url, { replace: true })
+              navigate(resultUrl, { replace: true })
             }
           },
           onError: (error) => {

--- a/src/providers/RouterProvider.tsx
+++ b/src/providers/RouterProvider.tsx
@@ -24,8 +24,23 @@ export function RouterProvider() {
         </Route>
       </Route>
 
-      {/* 시험 응시 — 헤더/푸터 없이 전체화면 전용 레이아웃 */}
-      <Route path="quiz/:quizId/exam" element={<QuizExamPage />} />
+      {/* 시험 응시/결과 — 헤더/푸터 없이 전용 레이아웃 */}
+      <Route
+        path="quiz/:quizId/exam"
+        element={
+          <ProtectedRoute>
+            <QuizExamPage />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="quiz/:submissionId/result"
+        element={
+          <ProtectedRoute>
+            <QuizResultPage />
+          </ProtectedRoute>
+        }
+      />
 
       <Route element={<DefaultLayout />}>
         <Route index element={<HomePage />} />
@@ -42,17 +57,6 @@ export function RouterProvider() {
           <Route path="edit" element={<MypageEditPage />} />
           <Route path="change-password" element={<ChangePasswordPage />} />
           <Route path="quiz" element={<QuizListPage />} />
-        </Route>
-
-        <Route path="quiz/:quizId">
-          <Route
-            path="result"
-            element={
-              <ProtectedRoute>
-                <QuizResultPage />
-              </ProtectedRoute>
-            }
-          />
         </Route>
 
         <Route path="showcase" element={<ComponentShowcase />} />

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -23,7 +23,7 @@ export const useAuthStore = create<AuthState>()(
   devtools(
     (set) => ({
       isAuthenticated: !!localStorage.getItem('accessToken'),
-      isLoading: !!localStorage.getItem('accessToken'),
+      isLoading: true,
       accessToken: localStorage.getItem('accessToken'),
       user: null,
       login: (user, accessToken) => {

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -22,17 +22,20 @@ interface AuthState {
 export const useAuthStore = create<AuthState>()(
   devtools(
     (set) => ({
-      isAuthenticated: false,
-      isLoading: true,
-      accessToken: null,
+      isAuthenticated: !!localStorage.getItem('accessToken'),
+      isLoading: !!localStorage.getItem('accessToken'),
+      accessToken: localStorage.getItem('accessToken'),
       user: null,
-      login: (user, accessToken) =>
+      login: (user, accessToken) => {
+        localStorage.setItem('accessToken', accessToken)
         set(
           { isAuthenticated: true, isLoading: false, user, accessToken },
           undefined,
           'auth/login'
-        ),
-      logout: () =>
+        )
+      },
+      logout: () => {
+        localStorage.removeItem('accessToken')
         set(
           {
             isAuthenticated: false,
@@ -42,11 +45,14 @@ export const useAuthStore = create<AuthState>()(
           },
           undefined,
           'auth/logout'
-        ),
+        )
+      },
       setLoading: (loading) =>
         set({ isLoading: loading }, undefined, 'auth/setLoading'),
-      setAccessToken: (token) =>
-        set({ accessToken: token }, undefined, 'auth/setAccessToken'),
+      setAccessToken: (token) => {
+        localStorage.setItem('accessToken', token)
+        set({ accessToken: token }, undefined, 'auth/setAccessToken')
+      },
     }),
     { name: 'AuthStore' }
   )


### PR DESCRIPTION
## 관련 이슈

- 이번 릴리즈에 포함된 PR: #82, #83, #85

## 작업 내용

PR #80 (main sync, #75까지) 이후 develop에 반영된 변경사항을 main에 병합합니다.

## 변경 사항

- **fix** (#82): 소셜 로그인 후 로그인 화면에 머무는 현상 수정
- **feat** (#83): 쪽지시험 결과 확인 페이지 구현
  - submission_id 기반 결과 페이지 라우팅
  - SubmissionQuestion discriminated union 타입 개선
  - MSW 핸들러 및 목 데이터 타입 정합성 수정
- **refactor** (#85): accessToken 저장소 인메모리 → localStorage 전환

## 스크린샷 (선택)

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다