### PR TITLE
refactor: 커뮤니티·질의응답 링크를 외부 도메인 앵커 태그로 변경 (#88)

### DIFF
--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -56,18 +56,18 @@ export function Header({
               </button>
 
               <nav className="flex items-center gap-15">
-                <button
-                  onClick={() => navigate(ROUTES.COMMUNITY.LIST)}
+                <a
+                  href="https://community.ozcodingschool.site/"
                   className="hover:text-primary px-2.5 py-2.5 text-lg tracking-tight text-gray-900 transition-colors duration-150"
                 >
                   커뮤니티
-                </button>
-                <button
-                  onClick={() => navigate(ROUTES.QNA.LIST)}
+                </a>
+                <a
+                  href="https://qna.ozcodingschool.site/"
                   className="hover:text-primary px-2.5 py-2.5 text-lg tracking-tight text-gray-900 transition-colors duration-150"
                 >
                   질의응답
-                </button>
+                </a>
               </nav>
             </div>
 


### PR DESCRIPTION
## 관련 이슈

- closes #88 

## 작업 내용

- 헤더메뉴 중 외부 서비스로 이동하는 링크 HTML 앵커 태그로 변경 

## 변경 사항

- Header.tsx — 커뮤니티, 질의응답 메뉴를 <button onClick={navigate}> → <a href>로 변경

## 스크린샷 (선택)

## 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다
- [ ] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [ ] 컨벤션에 맞게 작성했습니다
