### PR TITLE
feat: 수강신청 페이지 라우트 추가 (#93)

### DIFF
--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -29,4 +29,6 @@ export const ROUTES = {
   COMMUNITY: {
     LIST: '/community',
   },
+
+  ENROLL: '/enroll',
 } as const

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from 'msw'
 import { deploymentsHandlers } from '@/features/exams/deployments'
+import { socialLoginHandlers } from '@/features/accounts/social-login'
 import { meHandlers } from '@/features/accounts/me'
 import { meEnrolledCoursesHandlers } from '@/features/accounts/me-enrolled-courses'
 import { checkCodeHandlers } from '@/features/exams/deployment-check-code'
@@ -21,6 +22,7 @@ export const handlers = [
   http.get('/api/health', () => {
     return HttpResponse.json({ status: 'ok' })
   }),
+  ...socialLoginHandlers,
   ...meHandlers,
   ...meEnrolledCoursesHandlers,
   ...deploymentsHandlers,

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,6 +1,5 @@
 import { http, HttpResponse } from 'msw'
 import { deploymentsHandlers } from '@/features/exams/deployments'
-import { socialLoginHandlers } from '@/features/accounts/social-login'
 import { meHandlers } from '@/features/accounts/me'
 import { meEnrolledCoursesHandlers } from '@/features/accounts/me-enrolled-courses'
 import { checkCodeHandlers } from '@/features/exams/deployment-check-code'
@@ -22,7 +21,6 @@ export const handlers = [
   http.get('/api/health', () => {
     return HttpResponse.json({ status: 'ok' })
   }),
-  ...socialLoginHandlers,
   ...meHandlers,
   ...meEnrolledCoursesHandlers,
   ...deploymentsHandlers,

--- a/src/pages/enroll/EnrollPage.tsx
+++ b/src/pages/enroll/EnrollPage.tsx
@@ -1,0 +1,9 @@
+import { useNavigate } from 'react-router'
+import { EnrollStudentModal } from '@/components/layout/Header/EnrollStudentModal'
+import { ROUTES } from '@/constants/routes'
+
+export function EnrollPage() {
+  const navigate = useNavigate()
+  const handleClose = () => navigate(ROUTES.HOME, { replace: true })
+  return <EnrollStudentModal isOpen onClose={handleClose} />
+}

--- a/src/pages/enroll/index.ts
+++ b/src/pages/enroll/index.ts
@@ -1,0 +1,1 @@
+export { EnrollPage } from './EnrollPage'

--- a/src/providers/RouterProvider.tsx
+++ b/src/providers/RouterProvider.tsx
@@ -6,6 +6,7 @@ import { LoginPage, SocialCallbackPage } from '@/pages/auth'
 import { SignupSelectPage, SignupPage } from '@/pages/signup'
 import { MypagePage, MypageEditPage, ChangePasswordPage } from '@/pages/mypage'
 import { QuizListPage, QuizExamPage, QuizResultPage } from '@/pages/quiz'
+import { EnrollPage } from '@/pages/enroll'
 import { ComponentShowcase } from '@/pages/ComponentShowcase'
 import { ProtectedRoute } from '@/components/common/ProtectedRoute'
 
@@ -58,6 +59,15 @@ export function RouterProvider() {
           <Route path="change-password" element={<ChangePasswordPage />} />
           <Route path="quiz" element={<QuizListPage />} />
         </Route>
+
+        <Route
+          path="enroll"
+          element={
+            <ProtectedRoute>
+              <EnrollPage />
+            </ProtectedRoute>
+          }
+        />
 
         <Route path="showcase" element={<ComponentShowcase />} />
       </Route>


### PR DESCRIPTION
## 관련 이슈

- closes #93 

## 작업 내용

-수강생 등록 모달을 독립 라우트(/enroll)로 접근할 수 있도록 페이지 컴포넌트 추가

## 변경 사항
  - src/pages/enroll/EnrollPage.tsx — EnrollStudentModal을 라우트로 렌더링하는 페이지 컴포넌트 추가, 닫기 시 홈으로 이동
  - src/constants/routes.ts — ROUTES.ENROLL 상수 추가 (/enroll)
  - src/providers/RouterProvider.tsx — /enroll 라우트 추가 (ProtectedRoute 적용)

## 스크린샷 (선택)

## 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다
- [ ] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [ ] 컨벤션에 맞게 작성했습니다
