### PR TITLE
feat: 쪽지시험 목록 상세보기/응시하기 버튼 hover·active 상태 스타일 적용

### DIFF
--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -4,6 +4,7 @@ export type ButtonVariant =
   | 'primary'
   | 'secondary'
   | 'outline'
+  | 'outline-neutral'
   | 'ghost'
   | 'danger'
 export type ButtonSize = 'sm' | 'md' | 'lg'
@@ -22,7 +23,9 @@ const variantClasses: Record<ButtonVariant, string> = {
   secondary:
     'bg-bg-muted text-text-heading border border-border-base hover:bg-gray-200 active:bg-gray-300 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed',
   outline:
-    'bg-primary-100 text-primary border border-primary hover:bg-primary-200 active:bg-primary-300 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:bg-gray-200 disabled:text-gray-600 disabled:border-gray-300 disabled:cursor-not-allowed',
+    'bg-primary-100 text-primary border border-primary hover:bg-primary-200 active:bg-primary-500 active:border-primary-800 active:text-text-inverse focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:bg-gray-200 disabled:text-gray-600 disabled:border-gray-300 disabled:cursor-not-allowed',
+  'outline-neutral':
+    'bg-transparent text-gray-600 border border-gray-300 hover:bg-primary-100 hover:border-primary hover:text-primary active:bg-primary-200 active:border-primary-700 active:text-primary-700 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed',
   ghost:
     'bg-transparent text-primary hover:bg-bg-accent active:bg-primary-100 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed',
   danger:

--- a/src/components/quiz/list/QuizCard/QuizCard.tsx
+++ b/src/components/quiz/list/QuizCard/QuizCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router'
 import { Button } from '@/components/common/Button'
+import type { ButtonVariant } from '@/components/common/Button'
 import { ROUTES } from '@/constants/routes'
 import { ExamThumbnail } from '@/components/quiz/list/ExamThumbnail'
 import { QuizCodeModal } from '@/components/quiz/list/QuizCodeModal'
@@ -20,6 +21,7 @@ interface QuizCardViewModel {
   badgeClassName: string
   subtitle: string
   buttonLabel: string
+  buttonVariant: ButtonVariant
   action: QuizCardAction
 }
 
@@ -39,6 +41,7 @@ function getQuizCardViewModel(item: DeploymentListItem): QuizCardViewModel {
       badgeClassName: 'bg-success-bg text-success-dark',
       subtitle: `${exam.subject.title} · ${exam_info.score ?? 0}점/${total_score}점 · ${exam_info.correct_answer_count ?? 0}/${question_count}개 정답`,
       buttonLabel: '상세보기',
+      buttonVariant: 'outline-neutral',
       action:
         submission_id != null
           ? {
@@ -57,6 +60,7 @@ function getQuizCardViewModel(item: DeploymentListItem): QuizCardViewModel {
     badgeClassName: 'bg-error-bg text-error-dark',
     subtitle: `${exam.subject.title} · 응시하고 점수를 확인해보세요!`,
     buttonLabel: '응시하기',
+    buttonVariant: 'outline',
     action: { type: 'openModal' },
   }
 }
@@ -115,7 +119,7 @@ export function QuizCard({ item }: QuizCardProps) {
 
       {/* 우측: CTA 버튼 */}
       <Button
-        variant="outline"
+        variant={vm.buttonVariant}
         size="md"
         className="w-[112px]"
         disabled={vm.action.type === 'disabled'}


### PR DESCRIPTION
## Summary

- `Button` 컴포넌트에 `outline-neutral` variant 추가 (상세보기 전용: 기본 회색, hover 연보라, active 보라)
- `outline` variant hover·active 상태 디자인 토큰 기준으로 수정 (응시하기 버튼)
- `QuizCard`의 상세보기 버튼을 `outline-neutral`, 응시하기 버튼을 `outline` variant로 분리 적용

## Test plan

- [ ] 쪽지시험 목록 페이지에서 상세보기 버튼 기본 상태 회색 확인
- [ ] 상세보기 버튼 hover 시 연보라 배경 전환 확인
- [ ] 응시하기 버튼 hover 시 연보라, active 시 solid 보라 전환 확인
- [ ] 기존 outline variant 사용 버튼 스타일 regression 없음 확인

Closes #86