### PR TITLE
feat: 아이디찾기 모달 구현 (#96)

### DIFF
--- a/src/components/auth/FindEmailModal.tsx
+++ b/src/components/auth/FindEmailModal.tsx
@@ -1,0 +1,226 @@
+import { useState } from 'react'
+import { Modal } from '@/components/common/Modal/Modal'
+import { Input } from '@/components/common/Input'
+import { Button } from '@/components/common/Button'
+import { useSendSms, useVerifySms } from '@/features/accounts/signup'
+import { useFindEmail } from '@/features/accounts/find-email'
+
+export interface FindEmailModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onFindPassword: () => void
+}
+
+export function FindEmailModal({
+  isOpen,
+  onClose,
+  onFindPassword,
+}: FindEmailModalProps) {
+  const [name, setName] = useState('')
+  const [phone, setPhone] = useState('')
+  const [smsCode, setSmsCode] = useState('')
+  const [smsToken, setSmsToken] = useState('')
+  const [smsSent, setSmsSent] = useState(false)
+  const [smsVerified, setSmsVerified] = useState(false)
+  const [foundEmail, setFoundEmail] = useState('')
+
+  const [nameError, setNameError] = useState('')
+  const [phoneError, setPhoneError] = useState('')
+  const [smsCodeError, setSmsCodeError] = useState('')
+  const [errorMessage, setErrorMessage] = useState('')
+
+  const { mutate: sendSms, isPending: isSendSmsPending } = useSendSms()
+  const { mutate: verifySms, isPending: isVerifySmsPending } = useVerifySms()
+  const { mutate: findEmail, isPending: isFindEmailPending } = useFindEmail()
+
+  const handleClose = () => {
+    setName('')
+    setPhone('')
+    setSmsCode('')
+    setSmsToken('')
+    setSmsSent(false)
+    setSmsVerified(false)
+    setFoundEmail('')
+    setNameError('')
+    setPhoneError('')
+    setSmsCodeError('')
+    setErrorMessage('')
+    onClose()
+  }
+
+  const handleSendSms = () => {
+    if (!phone) {
+      setPhoneError('휴대폰 번호를 입력해주세요.')
+      return
+    }
+    sendSms(
+      { phone_number: phone, purpose: 'find_email' },
+      {
+        onSuccess: () => setSmsSent(true),
+        onError: () => setPhoneError('SMS 발송에 실패했습니다.'),
+      }
+    )
+  }
+
+  const handleVerifySms = () => {
+    if (!smsCode) {
+      setSmsCodeError('인증번호를 입력해주세요.')
+      return
+    }
+    verifySms(
+      { phone_number: phone, purpose: 'find_email', code: smsCode },
+      {
+        onSuccess: (data) => {
+          setSmsToken(data.sms_token)
+          setSmsVerified(true)
+        },
+        onError: () => setSmsCodeError('인증번호가 올바르지 않습니다.'),
+      }
+    )
+  }
+
+  const handleFindEmail = () => {
+    if (!name) {
+      setNameError('이름을 입력해주세요.')
+      return
+    }
+    if (!smsVerified) {
+      setPhoneError('휴대폰 인증을 완료해주세요.')
+      return
+    }
+
+    findEmail(
+      { sms_token: smsToken, name },
+      {
+        onSuccess: (data) => setFoundEmail(data.email),
+        onError: () =>
+          setErrorMessage(
+            '입력한 이름과 휴대폰 번호로 등록된 아이디가 존재하지 않습니다.'
+          ),
+      }
+    )
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose} title="아이디 찾기">
+      {foundEmail ? (
+        /* 성공 화면 */
+        <div className="flex flex-col gap-6">
+          <p className="text-center text-sm text-gray-600">
+            입력하신 정보와 일치하는 아이디입니다.
+          </p>
+          <div className="flex items-center justify-center rounded-sm border border-gray-200 py-4">
+            <p className="text-base font-medium text-gray-900">{foundEmail}</p>
+          </div>
+          <div className="flex gap-2">
+            <Button variant="outline" fullWidth onClick={handleClose}>
+              로그인
+            </Button>
+            <Button
+              fullWidth
+              onClick={() => {
+                handleClose()
+                onFindPassword()
+              }}
+            >
+              비밀번호 찾기
+            </Button>
+          </div>
+        </div>
+      ) : (
+        /* 입력 화면 */
+        <div className="flex flex-col gap-4">
+          {errorMessage && (
+            <p className="text-center text-sm text-red-500">{errorMessage}</p>
+          )}
+
+          {/* 이름 */}
+          <Input
+            label="이름*"
+            placeholder="이름을 입력해주세요"
+            value={name}
+            onChange={(e) => {
+              setName(e.target.value)
+              setNameError('')
+            }}
+            isError={Boolean(nameError)}
+            errorMessage={nameError}
+            autoComplete="off"
+          />
+
+          {/* 휴대전화 */}
+          <div className="flex flex-col gap-2">
+            <p className="text-base text-gray-700">휴대전화*</p>
+            <div className="flex gap-2">
+              <Input
+                placeholder="숫자만 입력해주세요"
+                value={phone}
+                onChange={(e) => {
+                  setPhone(e.target.value)
+                  setPhoneError('')
+                }}
+                isError={Boolean(phoneError)}
+                errorMessage={phoneError}
+                className="flex-1"
+                autoComplete="off"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleSendSms}
+                loading={isSendSmsPending}
+                disabled={!phone || smsVerified}
+                className="shrink-0"
+              >
+                {smsSent ? '재발송' : '인증번호전송'}
+              </Button>
+            </div>
+            {smsSent && !smsVerified && (
+              <div className="flex gap-2">
+                <Input
+                  placeholder="인증번호 6자리를 입력해주세요"
+                  value={smsCode}
+                  onChange={(e) => {
+                    setSmsCode(e.target.value)
+                    setSmsCodeError('')
+                  }}
+                  isError={Boolean(smsCodeError)}
+                  errorMessage={smsCodeError}
+                  className="flex-1"
+                  autoComplete="off"
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleVerifySms}
+                  loading={isVerifySmsPending}
+                  disabled={!smsCode}
+                  className="shrink-0"
+                >
+                  인증번호확인
+                </Button>
+              </div>
+            )}
+            {smsVerified && (
+              <p className="text-sm text-green-600">
+                휴대폰 인증이 완료되었습니다.
+              </p>
+            )}
+            {phoneError && !smsSent && (
+              <p className="text-xs text-red-500">{phoneError}</p>
+            )}
+          </div>
+
+          <Button
+            fullWidth
+            onClick={handleFindEmail}
+            loading={isFindEmailPending}
+            disabled={!name || !smsVerified}
+          >
+            아이디 찾기
+          </Button>
+        </div>
+      )}
+    </Modal>
+  )
+}

--- a/src/components/auth/index.ts
+++ b/src/components/auth/index.ts
@@ -1,0 +1,2 @@
+export { FindEmailModal } from './FindEmailModal'
+export type { FindEmailModalProps } from './FindEmailModal'

--- a/src/features/accounts/find-email/handler.ts
+++ b/src/features/accounts/find-email/handler.ts
@@ -1,0 +1,1 @@
+export const findEmailHandlers: never[] = []

--- a/src/features/accounts/find-email/index.ts
+++ b/src/features/accounts/find-email/index.ts
@@ -1,0 +1,3 @@
+export type { FindEmailRequest, FindEmailResponse } from './types'
+export { useFindEmail } from './queries'
+export { findEmailHandlers } from './handler'

--- a/src/features/accounts/find-email/queries.ts
+++ b/src/features/accounts/find-email/queries.ts
@@ -1,0 +1,18 @@
+import { useMutation } from '@tanstack/react-query'
+import instance from '@/api/instance'
+import type { FindEmailRequest, FindEmailResponse } from './types'
+
+const findEmailApi = async (
+  body: FindEmailRequest
+): Promise<FindEmailResponse> => {
+  const { data } = await instance.post<FindEmailResponse>(
+    '/accounts/find-email',
+    body
+  )
+  return data
+}
+
+export const useFindEmail = () =>
+  useMutation({
+    mutationFn: findEmailApi,
+  })

--- a/src/features/accounts/find-email/types.ts
+++ b/src/features/accounts/find-email/types.ts
@@ -1,0 +1,8 @@
+export interface FindEmailRequest {
+  sms_token: string
+  name: string
+}
+
+export interface FindEmailResponse {
+  email: string
+}

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -8,7 +8,7 @@ import { meProfileImageHandlers } from '@/features/accounts/me-profile-image'
 import { deploymentDetailHandlers } from '@/features/exams/deployment-detail'
 import { deploymentStatusHandlers } from '@/features/exams/deployment-status'
 import { submissionsHandlers } from '@/features/exams/submissions'
-import { logoutHandlers } from '@/features/accounts/logout'
+// import { logoutHandlers } from '@/features/accounts/logout'
 import { courseListHandlers } from '@/features/course/list/handler'
 import { cohortHandlers } from '@/features/course/cohorts/handler'
 import { enrollStudentHandlers } from '@/features/accounts/enroll-student/handler'
@@ -31,7 +31,7 @@ export const handlers = [
   ...meProfileImageHandlers,
   ...deploymentDetailHandlers,
   ...submissionsHandlers,
-  ...logoutHandlers,
+  // ...logoutHandlers,
   ...courseListHandlers,
   ...cohortHandlers,
   ...enrollStudentHandlers,

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -6,6 +6,7 @@ import { PasswordInput } from '@/components/common/PasswordInput'
 import { Button } from '@/components/common/Button'
 import { SocialLoginButton } from '@/components/common/SocialLoginButton'
 import { AlertModal } from '@/components/common/Modal/AlertModal'
+import { FindEmailModal } from '@/components/auth/FindEmailModal'
 import { useLogin } from '@/features/accounts/login/queries'
 import { meQueries } from '@/features/accounts/me/queries'
 import { useAuthStore } from '@/stores/authStore'
@@ -24,6 +25,7 @@ export function LoginPage() {
   const [passwordError, setPasswordError] = useState('')
   const [alertMessage, setAlertMessage] = useState('')
   const [isAlertOpen, setIsAlertOpen] = useState(false)
+  const [isFindEmailOpen, setIsFindEmailOpen] = useState(false)
 
   const { mutate: login, isPending } = useLogin()
 
@@ -139,7 +141,7 @@ export function LoginPage() {
           />
           <PasswordInput
             label="비밀번호"
-            placeholder="6~15자리 영문 대소문자, 숫자, 특수문자 포함"
+            placeholder="6~15자리 영문 대소문자, 특수문자 포함"
             value={password}
             onChange={(e) => {
               setPassword(e.target.value)
@@ -149,7 +151,9 @@ export function LoginPage() {
             errorMessage={passwordError}
           />
           <div className="flex gap-2 text-sm text-gray-600">
-            <button type="button">아이디 찾기</button>
+            <button type="button" onClick={() => setIsFindEmailOpen(true)}>
+              아이디 찾기
+            </button>
             <span>|</span>
             <button type="button">비밀번호 찾기</button>
           </div>
@@ -169,6 +173,12 @@ export function LoginPage() {
         isOpen={isAlertOpen}
         onClose={() => setIsAlertOpen(false)}
         message={alertMessage}
+      />
+
+      <FindEmailModal
+        isOpen={isFindEmailOpen}
+        onClose={() => setIsFindEmailOpen(false)}
+        onFindPassword={() => {}}
       />
     </main>
   )

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -27,7 +27,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       })
       .catch(() => {
         queryClient.clear()
-        useAuthStore.getState().logout()
+        useAuthStore.getState().setLoading(false)
       })
       .finally(() => {
         setLoading(false)


### PR DESCRIPTION
## 관련 이슈

- closes #96  

## 작업 내용

-로그인 페이지에서 아이디 찾기 버튼 클릭 시 모달 오픈
SMS 인증 후 이름 + sms_token으로 이메일 찾기
성공 시 마스킹된 이메일 표시 + 로그인/비밀번호 찾기 버튼
실패 시 에러 메시지 표시

## 변경 사항

-

## 스크린샷 (선택)

## 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다
- [ ] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [ ] 컨벤션에 맞게 작성했습니다
