### PR TITLE
feat: 비밀번호 찾기 모달 구현 (#102)

### DIFF
--- a/src/components/find/FindEmailModal.tsx
+++ b/src/components/find/FindEmailModal.tsx
@@ -5,6 +5,36 @@ import { Button } from '@/components/common/Button'
 import { useSendSms, useVerifySms } from '@/features/accounts/signup'
 import { useFindEmail } from '@/features/accounts/find-email'
 
+function PersonIcon() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 200 200"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx="100" cy="100" r="100" fill="#CEC1F0" />
+      <circle cx="100" cy="74" r="26" stroke="#6218D1" strokeWidth="12" />
+      <path
+        d="M54 163C54 133.729 74.5949 110 100 110C125.405 110 146 133.729 146 163"
+        stroke="#6218D1"
+        strokeWidth="12"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}
+
+function ModalHeader({ title }: { title: string }) {
+  return (
+    <div className="flex flex-col items-center gap-2 pt-4 pb-4">
+      <PersonIcon />
+      <h2 className="text-xl font-semibold text-gray-900">{title}</h2>
+    </div>
+  )
+}
+
 export interface FindEmailModalProps {
   isOpen: boolean
   onClose: () => void
@@ -102,10 +132,11 @@ export function FindEmailModal({
   }
 
   return (
-    <Modal isOpen={isOpen} onClose={handleClose} title="아이디 찾기">
+    <Modal isOpen={isOpen} onClose={handleClose}>
       {foundEmail ? (
         /* 성공 화면 */
-        <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-4">
+          <ModalHeader title="아이디 찾기" />
           <p className="text-center text-sm text-gray-600">
             입력하신 정보와 일치하는 아이디입니다.
           </p>
@@ -129,28 +160,35 @@ export function FindEmailModal({
         </div>
       ) : (
         /* 입력 화면 */
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-5">
+          <ModalHeader title="아이디 찾기" />
           {errorMessage && (
             <p className="text-center text-sm text-red-500">{errorMessage}</p>
           )}
 
           {/* 이름 */}
-          <Input
-            label="이름*"
-            placeholder="이름을 입력해주세요"
-            value={name}
-            onChange={(e) => {
-              setName(e.target.value)
-              setNameError('')
-            }}
-            isError={Boolean(nameError)}
-            errorMessage={nameError}
-            autoComplete="off"
-          />
+          <div className="flex flex-col gap-2">
+            <p className="text-sm font-medium text-gray-700">
+              이름<span className="text-red-500">*</span>
+            </p>
+            <Input
+              placeholder="이름을 입력해주세요"
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value)
+                setNameError('')
+              }}
+              isError={Boolean(nameError)}
+              errorMessage={nameError}
+              autoComplete="off"
+            />
+          </div>
 
           {/* 휴대전화 */}
           <div className="flex flex-col gap-2">
-            <p className="text-base text-gray-700">휴대전화*</p>
+            <p className="text-sm font-medium text-gray-700">
+              휴대전화<span className="text-red-500">*</span>
+            </p>
             <div className="flex gap-2">
               <Input
                 placeholder="숫자만 입력해주세요"
@@ -205,9 +243,6 @@ export function FindEmailModal({
               <p className="text-sm text-green-600">
                 휴대폰 인증이 완료되었습니다.
               </p>
-            )}
-            {phoneError && !smsSent && (
-              <p className="text-xs text-red-500">{phoneError}</p>
             )}
           </div>
 

--- a/src/components/find/FindEmailModal.tsx
+++ b/src/components/find/FindEmailModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { UserRound } from 'lucide-react'
 import { Modal } from '@/components/common/Modal/Modal'
 import { Input } from '@/components/common/Input'
 import { Button } from '@/components/common/Button'
@@ -7,22 +8,9 @@ import { useFindEmail } from '@/features/accounts/find-email'
 
 function PersonIcon() {
   return (
-    <svg
-      width="24"
-      height="24"
-      viewBox="0 0 200 200"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <circle cx="100" cy="100" r="100" fill="#CEC1F0" />
-      <circle cx="100" cy="74" r="26" stroke="#6218D1" strokeWidth="12" />
-      <path
-        d="M54 163C54 133.729 74.5949 110 100 110C125.405 110 146 133.729 146 163"
-        stroke="#6218D1"
-        strokeWidth="12"
-        strokeLinecap="round"
-      />
-    </svg>
+    <div className="flex h-12 w-12 items-center justify-center rounded-full bg-purple-200">
+      <UserRound size={24} stroke="#6218D1" />
+    </div>
   )
 }
 

--- a/src/components/find/FindPasswordModal.tsx
+++ b/src/components/find/FindPasswordModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import type { AxiosError } from 'axios'
+import { LockKeyhole } from 'lucide-react'
 import { Modal } from '@/components/common/Modal/Modal'
 import { Input } from '@/components/common/Input'
 import { PasswordInput } from '@/components/common/PasswordInput'
@@ -9,23 +10,9 @@ import { useFindPassword } from '@/features/accounts/find-password'
 
 function LockIcon() {
   return (
-    <svg
-      width="30"
-      height="30"
-      viewBox="0 0 200 200"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <circle cx="100" cy="100" r="80" fill="#D1B3FF" />
-      <path
-        d="M75 90V80C75 66.1929 86.1929 55 100 55C113.807 55 125 66.1929 125 80V90"
-        stroke="#5E00B1"
-        strokeWidth="10"
-        strokeLinecap="round"
-      />
-      <circle cx="100" cy="115" r="35" stroke="#5E00B1" strokeWidth="10" />
-      <circle cx="100" cy="115" r="8" fill="#5E00B1" />
-    </svg>
+    <div className="flex h-12 w-12 items-center justify-center rounded-full bg-purple-200">
+      <LockKeyhole size={24} stroke="#5E00B1" />
+    </div>
   )
 }
 

--- a/src/components/find/FindPasswordModal.tsx
+++ b/src/components/find/FindPasswordModal.tsx
@@ -1,0 +1,364 @@
+import { useState, useEffect, useCallback } from 'react'
+import type { AxiosError } from 'axios'
+import { Modal } from '@/components/common/Modal/Modal'
+import { Input } from '@/components/common/Input'
+import { PasswordInput } from '@/components/common/PasswordInput'
+import { Button } from '@/components/common/Button'
+import { useSendEmail, useVerifyEmail } from '@/features/accounts/signup'
+import { useFindPassword } from '@/features/accounts/find-password'
+
+function LockIcon() {
+  return (
+    <svg
+      width="30"
+      height="30"
+      viewBox="0 0 200 200"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx="100" cy="100" r="80" fill="#D1B3FF" />
+      <path
+        d="M75 90V80C75 66.1929 86.1929 55 100 55C113.807 55 125 66.1929 125 80V90"
+        stroke="#5E00B1"
+        strokeWidth="10"
+        strokeLinecap="round"
+      />
+      <circle cx="100" cy="115" r="35" stroke="#5E00B1" strokeWidth="10" />
+      <circle cx="100" cy="115" r="8" fill="#5E00B1" />
+    </svg>
+  )
+}
+
+function ModalHeader({
+  title,
+  description,
+}: {
+  title: string
+  description: string
+}) {
+  return (
+    <div className="flex flex-col items-center gap-2 pt-4 pb-4">
+      <LockIcon />
+      <h2 className="text-xl font-semibold text-gray-900">{title}</h2>
+      <p className="text-sm text-gray-500">{description}</p>
+    </div>
+  )
+}
+
+export interface FindPasswordModalProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function FindPasswordModal({ isOpen, onClose }: FindPasswordModalProps) {
+  const [email, setEmail] = useState('')
+  const [emailCode, setEmailCode] = useState('')
+  const [emailToken, setEmailToken] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [newPasswordConfirm, setNewPasswordConfirm] = useState('')
+
+  const [emailSent, setEmailSent] = useState(false)
+  const [emailVerified, setEmailVerified] = useState(false)
+  const [isSuccess, setIsSuccess] = useState(false)
+  const [countdown, setCountdown] = useState(0)
+  const [timer, setTimer] = useState(0)
+
+  const [emailError, setEmailError] = useState('')
+  const [emailCodeError, setEmailCodeError] = useState('')
+  const [newPasswordError, setNewPasswordError] = useState('')
+  const [newPasswordConfirmError, setNewPasswordConfirmError] = useState('')
+
+  const { mutate: sendEmail, isPending: isSendEmailPending } = useSendEmail()
+  const { mutate: verifyEmail, isPending: isVerifyEmailPending } =
+    useVerifyEmail()
+  const { mutate: findPassword, isPending: isFindPasswordPending } =
+    useFindPassword()
+
+  const handleClose = useCallback(() => {
+    setEmail('')
+    setEmailCode('')
+    setEmailToken('')
+    setNewPassword('')
+    setNewPasswordConfirm('')
+    setEmailSent(false)
+    setEmailVerified(false)
+    setIsSuccess(false)
+    setCountdown(0)
+    setTimer(0)
+    setEmailError('')
+    setEmailCodeError('')
+    setNewPasswordError('')
+    setNewPasswordConfirmError('')
+    onClose()
+  }, [onClose])
+
+  useEffect(() => {
+    if (timer <= 0) return
+    const interval = setInterval(() => {
+      setTimer((prev) => {
+        if (prev <= 1) {
+          clearInterval(interval)
+          return 0
+        }
+        return prev - 1
+      })
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [timer])
+
+  useEffect(() => {
+    if (!isSuccess) return
+    const interval = setInterval(() => {
+      setCountdown((prev) => {
+        if (prev <= 1) {
+          clearInterval(interval)
+          handleClose()
+          return 0
+        }
+        return prev - 1
+      })
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [isSuccess, handleClose])
+
+  const formatTime = (seconds: number) => {
+    const m = Math.floor(seconds / 60)
+      .toString()
+      .padStart(2, '0')
+    const s = (seconds % 60).toString().padStart(2, '0')
+    return `${m}:${s}`
+  }
+
+  const handleSendEmail = () => {
+    if (!email) {
+      setEmailError('이메일을 입력해주세요.')
+      return
+    }
+    sendEmail(
+      { email, purpose: 'find_password' },
+      {
+        onSuccess: () => {
+          setEmailSent(true)
+          setTimer(300)
+        },
+        onError: (error: unknown) => {
+          const axiosError = error as AxiosError<{
+            error_detail?: string | string[] | { email?: string[] }
+          }>
+          const errorDetail = axiosError.response?.data?.error_detail
+          if (Array.isArray(errorDetail)) {
+            setEmailError(errorDetail[0])
+          } else if (typeof errorDetail === 'string') {
+            setEmailError(errorDetail)
+          } else if (errorDetail?.email) {
+            setEmailError(errorDetail.email[0])
+          } else {
+            setEmailError('이메일 발송에 실패했습니다.')
+          }
+        },
+      }
+    )
+  }
+
+  const handleVerifyEmail = () => {
+    if (!emailCode) {
+      setEmailCodeError('인증번호를 입력해주세요.')
+      return
+    }
+    verifyEmail(
+      { email, purpose: 'find_password', code: emailCode },
+      {
+        onSuccess: (data) => {
+          setEmailToken(data.email_token)
+          setEmailVerified(true)
+          setTimer(0)
+        },
+        onError: () => setEmailCodeError('인증번호가 올바르지 않습니다.'),
+      }
+    )
+  }
+
+  const handleFindPassword = () => {
+    if (!newPassword) {
+      setNewPasswordError('비밀번호를 입력해주세요.')
+      return
+    }
+    if (newPassword !== newPasswordConfirm) {
+      setNewPasswordConfirmError('비밀번호가 일치하지 않습니다.')
+      return
+    }
+    findPassword(
+      { email_token: emailToken, new_password: newPassword },
+      {
+        onSuccess: () => {
+          setIsSuccess(true)
+          setCountdown(10)
+        },
+        onError: (error: unknown) => {
+          const axiosError = error as AxiosError<{
+            error_detail?: string | string[] | { new_password?: string[] }
+          }>
+          const errorDetail = axiosError.response?.data?.error_detail
+          if (Array.isArray(errorDetail)) {
+            setNewPasswordError(errorDetail[0])
+          } else if (typeof errorDetail === 'string') {
+            setNewPasswordError(errorDetail)
+          } else if (errorDetail?.new_password) {
+            setNewPasswordError(errorDetail.new_password[0])
+          } else {
+            setNewPasswordError('비밀번호 변경에 실패했습니다.')
+          }
+        },
+      }
+    )
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose}>
+      {isSuccess ? (
+        <div className="flex flex-col items-center gap-4 py-6">
+          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+              <path
+                d="M5 13l4 4L19 7"
+                stroke="#16a34a"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </div>
+          <p className="text-lg font-semibold text-gray-900">
+            비밀번호 변경 완료!
+          </p>
+          <p className="text-sm text-gray-500">
+            잠시 후 로그인 페이지로 이동합니다.
+          </p>
+          <p className="text-sm text-gray-400">
+            {countdown}초 후 로그인 페이지로 이동합니다.
+          </p>
+          <Button fullWidth onClick={handleClose}>
+            확인
+          </Button>
+        </div>
+      ) : emailVerified ? (
+        <div className="flex flex-col gap-5">
+          <ModalHeader
+            title="비밀번호 재설정"
+            description="신규 비밀번호를 입력해주세요."
+          />
+          <div className="flex flex-col gap-2">
+            <p className="text-sm font-medium text-gray-700">
+              새 비밀번호<span className="text-red-500">*</span>
+              <span className="text-primary ml-2 text-xs">
+                6~15자리 영문 대소문자, 숫자, 특수문자 포함
+              </span>
+            </p>
+            <PasswordInput
+              placeholder="비밀번호를 입력해주세요"
+              value={newPassword}
+              onChange={(e) => {
+                setNewPassword(e.target.value)
+                setNewPasswordError('')
+              }}
+              isError={Boolean(newPasswordError)}
+              errorMessage={newPasswordError}
+              autoComplete="new-password"
+            />
+          </div>
+          <PasswordInput
+            placeholder="비밀번호를 다시 입력해주세요"
+            value={newPasswordConfirm}
+            onChange={(e) => {
+              setNewPasswordConfirm(e.target.value)
+              setNewPasswordConfirmError('')
+            }}
+            isError={Boolean(newPasswordConfirmError)}
+            errorMessage={newPasswordConfirmError}
+            autoComplete="new-password"
+          />
+          <Button
+            fullWidth
+            onClick={handleFindPassword}
+            loading={isFindPasswordPending}
+            disabled={!newPassword || !newPasswordConfirm}
+          >
+            확인
+          </Button>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-5">
+          <ModalHeader
+            title="비밀번호 찾기"
+            description="이메일로 비밀번호 재설정 링크를 보내드려요."
+          />
+          <div className="flex flex-col gap-3">
+            <p className="text-sm font-medium text-gray-700">
+              이메일<span className="text-red-500">*</span>
+            </p>
+            <div className="flex gap-2">
+              <Input
+                type="email"
+                placeholder="가입한 이메일을 입력해 주세요."
+                value={email}
+                onChange={(e) => {
+                  setEmail(e.target.value)
+                  setEmailError('')
+                }}
+                isError={Boolean(emailError)}
+                errorMessage={emailError}
+                className="flex-1"
+                autoComplete="off"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleSendEmail}
+                loading={isSendEmailPending}
+                disabled={!email || emailVerified}
+                className="shrink-0"
+              >
+                {emailSent ? '재발송' : '인증코드전송'}
+              </Button>
+            </div>
+            {emailSent && !emailVerified && (
+              <div className="flex gap-2">
+                <div className="relative flex-1">
+                  <Input
+                    placeholder="인증번호 6자리를 입력해주세요"
+                    value={emailCode}
+                    onChange={(e) => {
+                      setEmailCode(e.target.value)
+                      setEmailCodeError('')
+                    }}
+                    isError={Boolean(emailCodeError)}
+                    errorMessage={emailCodeError}
+                    autoComplete="off"
+                  />
+                  {timer > 0 && (
+                    <span className="text-primary absolute top-3 right-3 text-sm">
+                      {formatTime(timer)}
+                    </span>
+                  )}
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleVerifyEmail}
+                  loading={isVerifyEmailPending}
+                  disabled={!emailCode || timer === 0}
+                  className="shrink-0"
+                >
+                  인증코드확인
+                </Button>
+              </div>
+            )}
+          </div>
+          <Button fullWidth onClick={() => {}} disabled={!emailVerified}>
+            비밀번호 찾기
+          </Button>
+        </div>
+      )}
+    </Modal>
+  )
+}

--- a/src/features/accounts/find-password/handler.ts
+++ b/src/features/accounts/find-password/handler.ts
@@ -1,0 +1,1 @@
+export const findPasswordHandlers: never[] = []

--- a/src/features/accounts/find-password/index.ts
+++ b/src/features/accounts/find-password/index.ts
@@ -1,0 +1,3 @@
+export type { FindPasswordRequest, FindPasswordResponse } from './types'
+export { useFindPassword } from './queries'
+export { findPasswordHandlers } from './handler'

--- a/src/features/accounts/find-password/queries.ts
+++ b/src/features/accounts/find-password/queries.ts
@@ -1,0 +1,18 @@
+import { useMutation } from '@tanstack/react-query'
+import instance from '@/api/instance'
+import type { FindPasswordRequest, FindPasswordResponse } from './types'
+
+const findPasswordApi = async (
+  body: FindPasswordRequest
+): Promise<FindPasswordResponse> => {
+  const { data } = await instance.post<FindPasswordResponse>(
+    '/accounts/find_password',
+    body
+  )
+  return data
+}
+
+export const useFindPassword = () =>
+  useMutation({
+    mutationFn: findPasswordApi,
+  })

--- a/src/features/accounts/find-password/types.ts
+++ b/src/features/accounts/find-password/types.ts
@@ -1,0 +1,8 @@
+export interface FindPasswordRequest {
+  email_token: string
+  new_password: string
+}
+
+export interface FindPasswordResponse {
+  detail: string
+}

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/common/Button'
 import { SocialLoginButton } from '@/components/common/SocialLoginButton'
 import { AlertModal } from '@/components/common/Modal/AlertModal'
 import { FindEmailModal } from '@/components/find/FindEmailModal'
+import { FindPasswordModal } from '@/components/find/FindPasswordModal'
 import { RestoreWithdrawnModal } from '@/components/auth/RestoreWithdrawnModal'
 import { useLogin } from '@/features/accounts/login/queries'
 import { meQueries } from '@/features/accounts/me/queries'
@@ -28,6 +29,7 @@ export function LoginPage() {
   const [alertMessage, setAlertMessage] = useState('')
   const [isAlertOpen, setIsAlertOpen] = useState(false)
   const [isFindEmailOpen, setIsFindEmailOpen] = useState(false)
+  const [isFindPasswordOpen, setIsFindPasswordOpen] = useState(false)
   const [isRestoreModalOpen, setIsRestoreModalOpen] = useState(false)
   const [withdrawnExpireAt, setWithdrawnExpireAt] = useState('')
 
@@ -143,7 +145,7 @@ export function LoginPage() {
           />
           <PasswordInput
             label="비밀번호"
-            placeholder="6~15자리 영문 대소문자, 특수문자 포함"
+            placeholder="6~15자리 영문 대소문자, 숫자, 특수문자 포함"
             value={password}
             onChange={(e) => {
               setPassword(e.target.value)
@@ -157,7 +159,9 @@ export function LoginPage() {
               아이디 찾기
             </button>
             <span>|</span>
-            <button type="button">비밀번호 찾기</button>
+            <button type="button" onClick={() => setIsFindPasswordOpen(true)}>
+              비밀번호 찾기
+            </button>
           </div>
 
           <Button
@@ -180,7 +184,15 @@ export function LoginPage() {
       <FindEmailModal
         isOpen={isFindEmailOpen}
         onClose={() => setIsFindEmailOpen(false)}
-        onFindPassword={() => {}}
+        onFindPassword={() => {
+          setIsFindEmailOpen(false)
+          setIsFindPasswordOpen(true)
+        }}
+      />
+
+      <FindPasswordModal
+        isOpen={isFindPasswordOpen}
+        onClose={() => setIsFindPasswordOpen(false)}
       />
       <RestoreWithdrawnModal
         isOpen={isRestoreModalOpen}


### PR DESCRIPTION
## 관련 이슈

- closes #102 

## 작업 내용

이메일 인증(5분 타이머) → 새 비밀번호 입력 → 변경 완료 (10초 카운트다운)
백엔드 에러 메시지 그대로 표시 (가입되지 않은 이메일, 기존 비밀번호 동일 등)
로그인 페이지에 비밀번호 찾기 모달 연결
아이디 찾기에서 비밀번호 찾기 모달로 전환 기능

## 변경 사항

src/features/accounts/find-password/types.ts
src/features/accounts/find-password/queries.ts
src/features/accounts/find-password/handler.ts
src/features/accounts/find-password/index.ts
src/components/find/FindPasswordModal.tsx
src/pages/auth/LoginPage.tsx — 비밀번호 찾기 모달 연결

## 스크린샷 (선택)

## 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다
- [ ] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [ ] 컨벤션에 맞게 작성했습니다
