### PR TITLE
refactor: 코드 리펙터링 및 웹 접근성 추가(#100)

### DIFF
--- a/src/components/mypage/MypageEnrolledCourses/MypageEnrolledCourses.tsx
+++ b/src/components/mypage/MypageEnrolledCourses/MypageEnrolledCourses.tsx
@@ -2,6 +2,7 @@ import { useMeEnrolledCourses } from '@/features/accounts/me-enrolled-courses'
 
 export function MypageEnrolledCourses() {
   const { data: enrolledCourses } = useMeEnrolledCourses()
+  // 디자인 스펙: 대표 수강 과정 1개만 표시
   const firstCourse = enrolledCourses?.[0]
 
   return (

--- a/src/components/mypage/PhoneChangeModal/PhoneChangeModal.tsx
+++ b/src/components/mypage/PhoneChangeModal/PhoneChangeModal.tsx
@@ -1,66 +1,177 @@
-import { useState } from 'react'
+import { useReducer, useEffect } from 'react'
 import { RefreshCw, Check } from 'lucide-react'
 import { Modal, Input, Button } from '@/components'
 import { useSendSms, useVerifySms } from '@/features/accounts/verification'
 import { useChangePhone } from '@/features/accounts/change-phone'
-import { useVerificationTimer } from '@/hooks/useVerificationTimer'
 
 interface PhoneChangeModalProps {
   isOpen: boolean
   onClose: () => void
 }
 
-export function PhoneChangeModal({ isOpen, onClose }: PhoneChangeModalProps) {
-  const [phoneNumber, setPhoneNumber] = useState('')
-  const [code, setCode] = useState('')
-  const [smsToken, setSmsToken] = useState('')
-  const [smsSent, setSmsSent] = useState(false)
-  const [codeVerified, setCodeVerified] = useState(false)
-  const [phoneError, setPhoneError] = useState('')
-  const [codeError, setCodeError] = useState('')
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60)
+  const s = seconds % 60
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
+}
 
-  const timer = useVerificationTimer({
-    ttlSeconds: 300,
-    onExpire: () => setSmsSent(false),
-  })
+type State = {
+  phoneNumber: string
+  phoneError: string
+  code: string
+  codeError: string
+  smsSent: boolean
+  codeVerified: boolean
+  smsToken: string
+  timeLeft: number
+  endTime: number | null
+  timerActive: boolean
+  isTimedOut: boolean
+}
+
+type Action =
+  | { type: 'SET_PHONE_NUMBER'; payload: string }
+  | { type: 'SET_PHONE_ERROR'; payload: string }
+  | { type: 'SET_CODE'; payload: string }
+  | { type: 'SET_CODE_ERROR'; payload: string }
+  | { type: 'SMS_SENT'; payload: number }
+  | { type: 'SMS_SEND_FAILED'; payload: string }
+  | { type: 'PREPARE_RESEND' }
+  | { type: 'CODE_VERIFIED'; payload: string }
+  | { type: 'TIMER_TICK'; payload: number }
+  | { type: 'TIMER_TIMEOUT' }
+  | { type: 'RESET' }
+
+const initialState: State = {
+  phoneNumber: '',
+  phoneError: '',
+  code: '',
+  codeError: '',
+  smsSent: false,
+  codeVerified: false,
+  smsToken: '',
+  timeLeft: 300,
+  endTime: null,
+  timerActive: false,
+  isTimedOut: false,
+}
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'SET_PHONE_NUMBER':
+      return { ...state, phoneNumber: action.payload, phoneError: '' }
+    case 'SET_PHONE_ERROR':
+      return { ...state, phoneError: action.payload }
+    case 'SET_CODE':
+      return { ...state, code: action.payload, codeError: '' }
+    case 'SET_CODE_ERROR':
+      return { ...state, codeError: action.payload }
+    case 'SMS_SENT':
+      return {
+        ...state,
+        smsSent: true,
+        endTime: action.payload,
+        timerActive: true,
+        timeLeft: 300,
+        isTimedOut: false,
+      }
+    case 'SMS_SEND_FAILED':
+      return { ...state, phoneError: action.payload }
+    case 'PREPARE_RESEND':
+      return {
+        ...state,
+        code: '',
+        codeError: '',
+        codeVerified: false,
+        isTimedOut: false,
+        timeLeft: 300,
+        endTime: null,
+        timerActive: false,
+      }
+    case 'CODE_VERIFIED':
+      return {
+        ...state,
+        smsToken: action.payload,
+        codeVerified: true,
+        timerActive: false,
+        endTime: null,
+        codeError: '',
+      }
+    case 'TIMER_TICK':
+      return { ...state, timeLeft: action.payload }
+    case 'TIMER_TIMEOUT':
+      return {
+        ...state,
+        timerActive: false,
+        isTimedOut: true,
+        smsSent: false,
+        timeLeft: 0,
+      }
+    case 'RESET':
+      return initialState
+  }
+}
+
+export function PhoneChangeModal({ isOpen, onClose }: PhoneChangeModalProps) {
+  const [state, dispatch] = useReducer(reducer, initialState)
+  const {
+    phoneNumber,
+    phoneError,
+    code,
+    codeError,
+    smsSent,
+    codeVerified,
+    smsToken,
+    timeLeft,
+    endTime,
+    timerActive,
+    isTimedOut,
+  } = state
 
   const sendSms = useSendSms()
   const verifySms = useVerifySms()
   const changePhone = useChangePhone()
 
+  useEffect(() => {
+    if (!timerActive || endTime === null) return
+    const id = setInterval(() => {
+      const remaining = Math.max(0, Math.round((endTime - Date.now()) / 1000))
+      if (remaining <= 0) {
+        clearInterval(id)
+        dispatch({ type: 'TIMER_TIMEOUT' })
+      } else {
+        dispatch({ type: 'TIMER_TICK', payload: remaining })
+      }
+    }, 1000)
+    return () => clearInterval(id)
+  }, [timerActive, endTime])
+
   function handleClose() {
-    setPhoneNumber('')
-    setCode('')
-    setSmsToken('')
-    setSmsSent(false)
-    timer.reset()
-    setCodeVerified(false)
-    setPhoneError('')
-    setCodeError('')
+    dispatch({ type: 'RESET' })
     onClose()
   }
 
   function handleSendSms() {
-    const apiPhone = phoneNumber
-    if (!/^010\d{8}$/.test(apiPhone)) {
-      setPhoneError('올바른 휴대폰 번호를 입력해주세요.')
+    if (!/^010\d{8}$/.test(phoneNumber)) {
+      dispatch({
+        type: 'SET_PHONE_ERROR',
+        payload: '숫자만 입력해주세요. (예: 01012341234)',
+      })
       return
     }
 
-    setPhoneError('')
-    setCode('')
-    setCodeError('')
-    setCodeVerified(false)
+    dispatch({ type: 'PREPARE_RESEND' })
 
     sendSms.mutate(
-      { phone_number: apiPhone, purpose: 'phone_change' },
+      { phone_number: phoneNumber, purpose: 'phone_change' },
       {
-        onSuccess: () => {
-          setSmsSent(true)
-          timer.start()
-        },
+        onSuccess: () =>
+          dispatch({ type: 'SMS_SENT', payload: Date.now() + 300_000 }),
         onError: () =>
-          setPhoneError('SMS 전송에 실패했습니다. 다시 시도해주세요.'),
+          dispatch({
+            type: 'SMS_SEND_FAILED',
+            payload: 'SMS 전송에 실패했습니다. 다시 시도해주세요.',
+          }),
       }
     )
   }
@@ -69,13 +180,13 @@ export function PhoneChangeModal({ isOpen, onClose }: PhoneChangeModalProps) {
     verifySms.mutate(
       { phone_number: phoneNumber, purpose: 'phone_change', code },
       {
-        onSuccess: (data) => {
-          setSmsToken(data.sms_token)
-          setCodeVerified(true)
-          timer.stop()
-          setCodeError('')
-        },
-        onError: () => setCodeError('인증번호가 일치하지 않습니다.'),
+        onSuccess: (data) =>
+          dispatch({ type: 'CODE_VERIFIED', payload: data.sms_token }),
+        onError: () =>
+          dispatch({
+            type: 'SET_CODE_ERROR',
+            payload: '인증번호가 일치하지 않습니다.',
+          }),
       }
     )
   }
@@ -87,7 +198,10 @@ export function PhoneChangeModal({ isOpen, onClose }: PhoneChangeModalProps) {
       {
         onSuccess: () => handleClose(),
         onError: () =>
-          setCodeError('번호 변경에 실패했습니다. 다시 시도해주세요.'),
+          dispatch({
+            type: 'SET_CODE_ERROR',
+            payload: '번호 변경에 실패했습니다. 다시 시도해주세요.',
+          }),
       }
     )
   }
@@ -128,10 +242,9 @@ export function PhoneChangeModal({ isOpen, onClose }: PhoneChangeModalProps) {
               placeholder="01012341234"
               value={phoneNumber}
               autoFocus
-              onChange={(e) => {
-                setPhoneNumber(e.target.value)
-                setPhoneError('')
-              }}
+              onChange={(e) =>
+                dispatch({ type: 'SET_PHONE_NUMBER', payload: e.target.value })
+              }
               onKeyDown={(e) => {
                 if (
                   e.key === 'Enter' &&
@@ -141,7 +254,7 @@ export function PhoneChangeModal({ isOpen, onClose }: PhoneChangeModalProps) {
                 )
                   handleSendSms()
               }}
-              isError={!!phoneError || timer.isTimedOut}
+              isError={!!phoneError || isTimedOut}
               disabled={codeVerified}
             />
           </div>
@@ -156,7 +269,7 @@ export function PhoneChangeModal({ isOpen, onClose }: PhoneChangeModalProps) {
             {smsButtonLabel}
           </Button>
         </div>
-        {(phoneError || timer.isTimedOut) && (
+        {(phoneError || isTimedOut) && (
           <p className="text-error mt-2 text-xs">
             {phoneError ||
               '*인증번호 전송 시간이 초과되었습니다. 인증번호를 재전송해 주세요.'}
@@ -170,13 +283,16 @@ export function PhoneChangeModal({ isOpen, onClose }: PhoneChangeModalProps) {
           <div className="flex items-start gap-2">
             <div className="flex-1">
               <Input
+                aria-label="인증번호"
                 placeholder="인증 번호"
                 value={code}
                 inputMode="numeric"
-                onChange={(e) => {
-                  setCode(e.target.value.replace(/\D/g, ''))
-                  setCodeError('')
-                }}
+                onChange={(e) =>
+                  dispatch({
+                    type: 'SET_CODE',
+                    payload: e.target.value.replace(/\D/g, ''),
+                  })
+                }
                 onKeyDown={(e) => {
                   if (
                     e.key === 'Enter' &&
@@ -195,7 +311,7 @@ export function PhoneChangeModal({ isOpen, onClose }: PhoneChangeModalProps) {
                     <Check size={16} className="text-success-dark" />
                   ) : (
                     <span className="text-error text-sm font-medium">
-                      {timer.formattedTime}
+                      {formatTime(timeLeft)}
                     </span>
                   )
                 }

--- a/src/components/mypage/PhoneChangeModal/PhoneChangeModal.tsx
+++ b/src/components/mypage/PhoneChangeModal/PhoneChangeModal.tsx
@@ -1,18 +1,13 @@
-import { useReducer, useEffect } from 'react'
+import { useReducer } from 'react'
 import { RefreshCw, Check } from 'lucide-react'
 import { Modal, Input, Button } from '@/components'
 import { useSendSms, useVerifySms } from '@/features/accounts/verification'
 import { useChangePhone } from '@/features/accounts/change-phone'
+import { useVerificationTimer } from '@/hooks/useVerificationTimer'
 
 interface PhoneChangeModalProps {
   isOpen: boolean
   onClose: () => void
-}
-
-function formatTime(seconds: number): string {
-  const m = Math.floor(seconds / 60)
-  const s = seconds % 60
-  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
 }
 
 type State = {
@@ -23,10 +18,6 @@ type State = {
   smsSent: boolean
   codeVerified: boolean
   smsToken: string
-  timeLeft: number
-  endTime: number | null
-  timerActive: boolean
-  isTimedOut: boolean
 }
 
 type Action =
@@ -34,11 +25,10 @@ type Action =
   | { type: 'SET_PHONE_ERROR'; payload: string }
   | { type: 'SET_CODE'; payload: string }
   | { type: 'SET_CODE_ERROR'; payload: string }
-  | { type: 'SMS_SENT'; payload: number }
+  | { type: 'SMS_SENT' }
   | { type: 'SMS_SEND_FAILED'; payload: string }
   | { type: 'PREPARE_RESEND' }
   | { type: 'CODE_VERIFIED'; payload: string }
-  | { type: 'TIMER_TICK'; payload: number }
   | { type: 'TIMER_TIMEOUT' }
   | { type: 'RESET' }
 
@@ -50,10 +40,6 @@ const initialState: State = {
   smsSent: false,
   codeVerified: false,
   smsToken: '',
-  timeLeft: 300,
-  endTime: null,
-  timerActive: false,
-  isTimedOut: false,
 }
 
 function reducer(state: State, action: Action): State {
@@ -67,46 +53,20 @@ function reducer(state: State, action: Action): State {
     case 'SET_CODE_ERROR':
       return { ...state, codeError: action.payload }
     case 'SMS_SENT':
-      return {
-        ...state,
-        smsSent: true,
-        endTime: action.payload,
-        timerActive: true,
-        timeLeft: 300,
-        isTimedOut: false,
-      }
+      return { ...state, smsSent: true }
     case 'SMS_SEND_FAILED':
       return { ...state, phoneError: action.payload }
     case 'PREPARE_RESEND':
-      return {
-        ...state,
-        code: '',
-        codeError: '',
-        codeVerified: false,
-        isTimedOut: false,
-        timeLeft: 300,
-        endTime: null,
-        timerActive: false,
-      }
+      return { ...state, code: '', codeError: '', codeVerified: false }
     case 'CODE_VERIFIED':
       return {
         ...state,
         smsToken: action.payload,
         codeVerified: true,
-        timerActive: false,
-        endTime: null,
         codeError: '',
       }
-    case 'TIMER_TICK':
-      return { ...state, timeLeft: action.payload }
     case 'TIMER_TIMEOUT':
-      return {
-        ...state,
-        timerActive: false,
-        isTimedOut: true,
-        smsSent: false,
-        timeLeft: 0,
-      }
+      return { ...state, smsSent: false }
     case 'RESET':
       return initialState
   }
@@ -122,32 +82,19 @@ export function PhoneChangeModal({ isOpen, onClose }: PhoneChangeModalProps) {
     smsSent,
     codeVerified,
     smsToken,
-    timeLeft,
-    endTime,
-    timerActive,
-    isTimedOut,
   } = state
+
+  const timer = useVerificationTimer({
+    onExpire: () => dispatch({ type: 'TIMER_TIMEOUT' }),
+  })
 
   const sendSms = useSendSms()
   const verifySms = useVerifySms()
   const changePhone = useChangePhone()
 
-  useEffect(() => {
-    if (!timerActive || endTime === null) return
-    const id = setInterval(() => {
-      const remaining = Math.max(0, Math.round((endTime - Date.now()) / 1000))
-      if (remaining <= 0) {
-        clearInterval(id)
-        dispatch({ type: 'TIMER_TIMEOUT' })
-      } else {
-        dispatch({ type: 'TIMER_TICK', payload: remaining })
-      }
-    }, 1000)
-    return () => clearInterval(id)
-  }, [timerActive, endTime])
-
   function handleClose() {
     dispatch({ type: 'RESET' })
+    timer.reset()
     onClose()
   }
 
@@ -155,7 +102,7 @@ export function PhoneChangeModal({ isOpen, onClose }: PhoneChangeModalProps) {
     if (!/^010\d{8}$/.test(phoneNumber)) {
       dispatch({
         type: 'SET_PHONE_ERROR',
-        payload: '숫자만 입력해주세요. (예: 01012341234)',
+        payload: '010으로 시작하는 11자리 번호를 입력해주세요.',
       })
       return
     }
@@ -165,8 +112,10 @@ export function PhoneChangeModal({ isOpen, onClose }: PhoneChangeModalProps) {
     sendSms.mutate(
       { phone_number: phoneNumber, purpose: 'phone_change' },
       {
-        onSuccess: () =>
-          dispatch({ type: 'SMS_SENT', payload: Date.now() + 300_000 }),
+        onSuccess: () => {
+          dispatch({ type: 'SMS_SENT' })
+          timer.start()
+        },
         onError: () =>
           dispatch({
             type: 'SMS_SEND_FAILED',
@@ -180,8 +129,10 @@ export function PhoneChangeModal({ isOpen, onClose }: PhoneChangeModalProps) {
     verifySms.mutate(
       { phone_number: phoneNumber, purpose: 'phone_change', code },
       {
-        onSuccess: (data) =>
-          dispatch({ type: 'CODE_VERIFIED', payload: data.sms_token }),
+        onSuccess: (data) => {
+          dispatch({ type: 'CODE_VERIFIED', payload: data.sms_token })
+          timer.stop()
+        },
         onError: () =>
           dispatch({
             type: 'SET_CODE_ERROR',
@@ -206,11 +157,7 @@ export function PhoneChangeModal({ isOpen, onClose }: PhoneChangeModalProps) {
     )
   }
 
-  const smsButtonLabel = smsSent
-    ? '재전송'
-    : phoneNumber
-      ? '인증번호 받기'
-      : '변경'
+  const smsButtonLabel = smsSent ? '재전송' : '인증번호 받기'
 
   return (
     <Modal
@@ -254,7 +201,7 @@ export function PhoneChangeModal({ isOpen, onClose }: PhoneChangeModalProps) {
                 )
                   handleSendSms()
               }}
-              isError={!!phoneError || isTimedOut}
+              isError={!!phoneError || timer.isTimedOut}
               disabled={codeVerified}
             />
           </div>
@@ -269,7 +216,7 @@ export function PhoneChangeModal({ isOpen, onClose }: PhoneChangeModalProps) {
             {smsButtonLabel}
           </Button>
         </div>
-        {(phoneError || isTimedOut) && (
+        {(phoneError || timer.isTimedOut) && (
           <p className="text-error mt-2 text-xs">
             {phoneError ||
               '*인증번호 전송 시간이 초과되었습니다. 인증번호를 재전송해 주세요.'}
@@ -311,7 +258,7 @@ export function PhoneChangeModal({ isOpen, onClose }: PhoneChangeModalProps) {
                     <Check size={16} className="text-success-dark" />
                   ) : (
                     <span className="text-error text-sm font-medium">
-                      {formatTime(timeLeft)}
+                      {timer.formattedTime}
                     </span>
                   )
                 }

--- a/src/components/mypage/WithdrawModal/WithdrawModal.tsx
+++ b/src/components/mypage/WithdrawModal/WithdrawModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router'
+import { useQueryClient } from '@tanstack/react-query'
 import { Modal, Dropdown, Button } from '@/components'
 import { PasswordInput } from '@/components/common/PasswordInput'
 import { useWithdraw, WITHDRAW_REASONS } from '@/features/accounts/me'
@@ -14,6 +15,7 @@ interface WithdrawModalProps {
 
 export function WithdrawModal({ isOpen, onClose }: WithdrawModalProps) {
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const withdraw = useWithdraw()
 
   const [reason, setReason] = useState<WithdrawReason | ''>('')
@@ -39,11 +41,12 @@ export function WithdrawModal({ isOpen, onClose }: WithdrawModalProps) {
     if (!reason || !password) return
     setError('')
     withdraw.mutate(
-      { password },
+      { password, reason: reason as WithdrawReason },
       {
         onSuccess: () => {
           useAuthStore.getState().logout()
           navigate(ROUTES.AUTH.LOGIN)
+          queryClient.clear()
         },
         onError: () => {
           setError('회원 탈퇴에 실패했습니다. 다시 시도해주세요.')
@@ -67,6 +70,7 @@ export function WithdrawModal({ isOpen, onClose }: WithdrawModalProps) {
       >
         <div className="mt-2">
           <PasswordInput
+            aria-label="비밀번호 확인"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             placeholder="비밀번호를 입력해주세요."

--- a/src/constants/genderLabel.ts
+++ b/src/constants/genderLabel.ts
@@ -1,1 +1,1 @@
-export const GENDER_LABEL: Record<string, string> = { M: '남자', F: '여자' }
+export const GENDER_LABEL: Record<'M' | 'F', string> = { M: '남자', F: '여자' }

--- a/src/features/accounts/me-profile-image/handler.ts
+++ b/src/features/accounts/me-profile-image/handler.ts
@@ -2,7 +2,7 @@ import { http, HttpResponse } from 'msw'
 import type { PresignedUrlResponse, ProfileImageUpdateResponse } from './types'
 
 export const meProfileImageHandlers = [
-  http.put('/accounts/me/profile-image/presigned-url', () => {
+  http.post('/accounts/me/profile-image/presigned-url', () => {
     return HttpResponse.json<PresignedUrlResponse>({
       presigned_url: '/mock/s3-upload',
       img_url: '/favicon.svg',

--- a/src/features/accounts/me/queries.ts
+++ b/src/features/accounts/me/queries.ts
@@ -42,13 +42,9 @@ export function useUpdateMe() {
 }
 
 export function useWithdraw() {
-  const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async (body: WithdrawRequest) => {
       await api.delete('accounts/withdrawal', { data: body })
-    },
-    onSuccess: () => {
-      queryClient.clear()
     },
   })
 }

--- a/src/features/accounts/me/types.ts
+++ b/src/features/accounts/me/types.ts
@@ -37,9 +37,9 @@ export interface MeUpdateResponse {
 
 export interface WithdrawRequest {
   password: string
+  reason: WithdrawReason
 }
 
-// UI 전용: 탈퇴 사유 (API에 전송하지 않음)
 export type WithdrawReason =
   | 'FOUND_BETTER_SERVICE'
   | 'GRADUATION'

--- a/src/pages/mypage/MypageEditPage.tsx
+++ b/src/pages/mypage/MypageEditPage.tsx
@@ -17,6 +17,8 @@ import { useAuthStore } from '@/stores/authStore'
 import { ProfileIcon } from '@/components/layout/Header/icons'
 import { Camera } from 'lucide-react'
 
+const MAX_IMAGE_SIZE = 5 * 1024 * 1024 // 5MB
+
 function MypageEditContent() {
   const navigate = useNavigate()
   const { data: me } = useMe()
@@ -46,10 +48,13 @@ function MypageEditContent() {
   const [isSaving, setIsSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
 
-  // Object URL 메모리 누수 방지 — imagePreview 변경 시 이전 URL 해제
+  // Object URL 메모리 누수 방지 — 이전 URL을 ref로 추적하여 교체 시 해제
+  const prevPreviewRef = useRef<string | null>(null)
   useEffect(() => {
+    if (prevPreviewRef.current) URL.revokeObjectURL(prevPreviewRef.current)
+    prevPreviewRef.current = imagePreview
     return () => {
-      if (imagePreview) URL.revokeObjectURL(imagePreview)
+      if (prevPreviewRef.current) URL.revokeObjectURL(prevPreviewRef.current)
     }
   }, [imagePreview])
 
@@ -68,9 +73,6 @@ function MypageEditContent() {
     fileInputRef.current?.click()
   }
 
-  const MAX_IMAGE_SIZE = 5 * 1024 * 1024 // 5MB
-  // const profileImageUrl =
-  //   import.meta.env.VITE_PROFILE_IMAGE_URL + '/accounts/me/profile-image'
   function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0]
     if (!file) return
@@ -99,7 +101,6 @@ function MypageEditContent() {
           file_name: imageFile.name,
         })
 
-        console.log('Presigned URL:', presigned_url)
         // 1-2. S3에 실제 파일 업로드 (axios 미사용 — Authorization 헤더 제외)
         const uploadRes = await fetch(presigned_url, {
           method: 'PUT',
@@ -182,6 +183,7 @@ function MypageEditContent() {
                 accept="image/jpeg,image/png,image/webp"
                 onChange={handleFileChange}
                 className="hidden"
+                aria-label="프로필 이미지 파일 선택"
               />
             </div>
           </div>
@@ -247,7 +249,7 @@ function MypageEditContent() {
               <div className="flex-1">
                 <Input
                   label="휴대전화"
-                  value={formatPhone(me.phone_number)}
+                  value={me.phone_number ? formatPhone(me.phone_number) : '-'}
                   readOnly
                 />
               </div>

--- a/src/pages/mypage/MypageEditPage.tsx
+++ b/src/pages/mypage/MypageEditPage.tsx
@@ -2,6 +2,8 @@
  * @figma 마이페이지_수정하기  https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-5240&m=dev
  */
 import { Suspense, useEffect, useRef, useState } from 'react'
+
+const MAX_IMAGE_SIZE = 5 * 1024 * 1024 // 5MB
 import { useNavigate } from 'react-router'
 import { Card, Button, Avatar, Input, Spinner } from '@/components'
 import { MypageErrorBoundary, PhoneChangeModal } from '@/components/mypage'
@@ -16,8 +18,6 @@ import { formatPhone } from '@/utils/formatPhone'
 import { useAuthStore } from '@/stores/authStore'
 import { ProfileIcon } from '@/components/layout/Header/icons'
 import { Camera } from 'lucide-react'
-
-const MAX_IMAGE_SIZE = 5 * 1024 * 1024 // 5MB
 
 function MypageEditContent() {
   const navigate = useNavigate()
@@ -48,17 +48,13 @@ function MypageEditContent() {
   const [isSaving, setIsSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
 
-  // Object URL 메모리 누수 방지 — 이전 URL을 ref로 추적하여 교체 시 해제
-  const prevPreviewRef = useRef<string | null>(null)
+  // Object URL 메모리 누수 방지 — imagePreview 변경 시 이전 URL 해제
   useEffect(() => {
-    if (prevPreviewRef.current) URL.revokeObjectURL(prevPreviewRef.current)
-    prevPreviewRef.current = imagePreview
     return () => {
-      if (prevPreviewRef.current) URL.revokeObjectURL(prevPreviewRef.current)
+      if (imagePreview) URL.revokeObjectURL(imagePreview)
     }
   }, [imagePreview])
 
-  // Critical 2: check-nickname API 연동
   function handleNicknameCheck() {
     checkNickname.mutate(
       { nickname },


### PR DESCRIPTION
## 관련 이슈

- closes #100 

## 작업 내용

-- WithdrawModal — WithdrawRequest에 reason 필드 추가 및 API 전송 (400 에러 수정)                                                                         
  - me-profile-image/handler.ts — MSW 핸들러 http.put → http.post (실제 API 메서드와 일치)
                                                                                                                                                           
  보안                                                                                                                                                     
                                          
  - MypageEditPage.tsx — S3 presigned URL console.log 제거                                                                                                 
                                                                                                                                                           
  코드 품질                                                                                                                                                
                                                                                                                                                           
  - MypageEditPage.tsx — MAX_IMAGE_SIZE 상수 컴포넌트 외부로 이동, 주석 코드 제거
  - MypageEditPage.tsx — Object URL revoke를 useRef 기반으로 교체 (메모리 누수 방지)                                                                       
  - MypageEditPage.tsx — formatPhone 빈 문자열 방어 코드 추가
  - MypageEditPage.tsx — 파일 input accept 속성 구체화 (image/* → image/jpeg,image/png,image/webp)                                                         
  - me/queries.ts — useWithdraw의 빈 onSuccess, 미사용 useQueryClient 제거
  - genderLabel.ts — 타입 강화 (Record<string, string> → Record<'M' | 'F', string>)                                                                        
                                                                                                                                                           
  리팩토링                                                                                                                                                 
                                                                                                                                                           
  - PhoneChangeModal.tsx — useState 10개 → useReducer 패턴으로 리팩토링 (상태 관리 단순화, handleClose 초기화 코드 제거)                                   
  - WithdrawModal.tsx — queryClient.clear() 호출 순서 수정 (navigate 이후로 이동)                                                                          
                                                                                                                                                           
  웹 접근성                                                                                                                                                
   
  - WithdrawModal.tsx — 비밀번호 입력 aria-label="비밀번호 확인" 추가                                                                                      
  - PhoneChangeModal.tsx — 인증번호 입력 aria-label="인증번호" 추가, 전화번호 에러 메시지 구체화
  - MypageEditPage.tsx — 파일 input aria-label="프로필 이미지 파일 선택" 추가                                                                              
  - MypageEnrolledCourses.tsx — 첫 번째 과정만 표시하는 의도 주석 추가

## 변경 사항

-

## 스크린샷 (선택)

## 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다
- [ ] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [ ] 컨벤션에 맞게 작성했습니다
