### PR TITLE
style: 수강생 등록 모달 아이콘 상단 패딩 추가 (#105)

### DIFF
--- a/src/components/layout/Header/EnrollStudentModal.tsx
+++ b/src/components/layout/Header/EnrollStudentModal.tsx
@@ -95,7 +95,7 @@ export function EnrollStudentModal({
       onClose={handleClose}
       maxWidth="w-full max-w-[396px] mx-auto"
     >
-      <div className="flex flex-col items-center gap-10">
+      <div className="flex flex-col items-center gap-10 pt-12.5">
         {/* 아이콘 + 제목 + 설명 */}
         <div className="flex flex-col items-center gap-4 text-center">
           <div className="bg-primary-300 flex h-8 w-8 items-center justify-center rounded-full">


### PR DESCRIPTION
## 관련 이슈

- closes #105 

## 작업 내용

-모달 아이콘 상단 패딩 추가

## 변경 사항

-`EnrollStudentModal` 콘텐츠 wrapper에 `pt-12.5` (50px) 추가

## 스크린샷 (선택)

## 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다
- [ ] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [ ] 컨벤션에 맞게 작성했습니다
