### PR TITLE
feat: 드롭다운 오픈 시 사용자 역할 갱신 및 수강생 등록 상태 반영

### DIFF
--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -8,6 +8,7 @@ import { ProfileDropdown } from './ProfileDropdown'
 import { EnrollStudentModal } from './EnrollStudentModal'
 import { useAuthStore } from '@/stores/authStore'
 import { useLogout } from '@/features/accounts/logout'
+import { meQueries } from '@/features/accounts/me'
 
 export interface HeaderProps {
   bannerText?: string
@@ -20,11 +21,25 @@ export function Header({
   const [enrollModalOpen, setEnrollModalOpen] = useState(false)
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const { isAuthenticated, isLoading, user, logout } = useAuthStore()
+  const { isAuthenticated, isLoading, user, logout, login } = useAuthStore()
   const { mutate: logoutApi } = useLogout()
 
-  const isEnrolled = user?.role === 'USER'
+  const isEnrolled = user?.role === 'STUDENT' || user?.role === 'ADMIN'
 
+  async function handleDropdownOpen() {
+    setDropdownOpen(true)
+    if (!isAuthenticated) return
+    const meData = await queryClient.fetchQuery(meQueries.detail())
+    login(
+      {
+        email: meData.email,
+        nickname: meData.nickname,
+        profileImage: meData.profile_img_url,
+        role: meData.role,
+      },
+      useAuthStore.getState().accessToken ?? ''
+    )
+  }
   return (
     <>
       <header className="flex w-full flex-col">
@@ -72,7 +87,7 @@ export function Header({
             ) : isAuthenticated && user ? (
               <div
                 className="relative"
-                onMouseEnter={() => setDropdownOpen(true)}
+                onMouseEnter={handleDropdownOpen}
                 onMouseLeave={() => setDropdownOpen(false)}
               >
                 <button

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -21,6 +21,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             email: meData.email,
             nickname: meData.nickname,
             profileImage: meData.profile_img_url,
+            role: meData.role,
           },
           useAuthStore.getState().accessToken ?? ''
         )


### PR DESCRIPTION
## 관련 이슈

- closes #107 

## 작업 내용
 - 드롭다운 열릴 때 `/accounts/me` 재요청하여 최신 role 반영
 - `AuthProvider`에서 누락된 `role` 저장 추가
 - `isEnrolled` 판단 로직을 `role === 'STUDENT' || role === 'ADMIN'`으로 수정

## 변경 사항
 - `AuthProvider.tsx` — `/accounts/me` 응답의 `role`을 authStore에 저장하도록 수정
 - `Header.tsx` — 드롭다운 오픈 시 `me` 쿼리 재요청 후 authStore 업데이트, `isEnrolled` 로직 수정

## 스크린샷 (선택)

## 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다
- [ ] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [ ] 컨벤션에 맞게 작성했습니다
