### PR TITLE
fix: 시험 제출 후 목록 페이지 응시하기 버튼 깜빡임 수정 (#116)

### DIFF
--- a/src/pages/quiz/exam/hooks/useExamSubmission.ts
+++ b/src/pages/quiz/exam/hooks/useExamSubmission.ts
@@ -9,7 +9,9 @@
 // 나머지는 즉시 결과 페이지로 리다이렉트한다.
 import { useState, useRef, useCallback } from 'react'
 import { useNavigate } from 'react-router'
+import { useQueryClient } from '@tanstack/react-query'
 import { useSubmitExam } from '@/features/exams/submissions'
+import { deploymentsQueries } from '@/features/exams/deployments'
 import { useToastStore } from '@/stores/toastStore'
 import { ROUTES } from '@/constants/routes'
 import { HTTP_STATUS } from '@/constants/httpStatus'
@@ -61,6 +63,7 @@ export function useExamSubmission({
   getSubmissionAnswers,
 }: UseExamSubmissionOptions): UseExamSubmissionResult {
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const showToast = useToastStore((s) => s.show)
   const { mutate: submitExam, isPending: isSubmitting } = useSubmitExam()
 
@@ -103,6 +106,9 @@ export function useExamSubmission({
               setIsSubmitted(false)
               return
             }
+            queryClient.removeQueries({
+              queryKey: deploymentsQueries.all().queryKey,
+            })
             const resultUrl = ROUTES.QUIZ.RESULT.replace(
               ':submissionId',
               String(res.submission_id)
@@ -130,7 +136,14 @@ export function useExamSubmission({
         }
       )
     },
-    [deploymentId, getSubmissionAnswers, submitExam, showToast, navigate]
+    [
+      deploymentId,
+      getSubmissionAnswers,
+      submitExam,
+      showToast,
+      navigate,
+      queryClient,
+    ]
   )
 
   const closeCompletionModal = useCallback(() => {


### PR DESCRIPTION
## 관련 이슈

- closes #116

## 작업 내용

시험 제출 완료 후 목록 페이지 이동 시 '응시하기' 버튼이 찰나 표시되는 문제 수정

## 변경 사항

- `useExamSubmission` — 제출 성공 시 `invalidateQueries` 대신 `removeQueries`로 deployments 캐시를 완전히 제거
- 기존: stale 마킹 → 목록 페이지 마운트 시 구 데이터(is_done: false) 잠깐 렌더링 → '응시하기' 깜빡임
- 변경: 캐시 제거 → 목록 페이지 마운트 시 스켈레톤 → 최신 데이터로 '상세보기' 표시

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다