### PR TITLE
fix: 이메일/비밀번호 찾기 모달 에러 처리 및 오버레이 클릭 닫힘 방지 (#120)

### DIFF
--- a/src/components/find/FindEmailModal.tsx
+++ b/src/components/find/FindEmailModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import type { AxiosError } from 'axios'
 import { UserRound } from 'lucide-react'
 import { Modal } from '@/components/common/Modal/Modal'
 import { Input } from '@/components/common/Input'
@@ -75,7 +76,21 @@ export function FindEmailModal({
       { phone_number: phone, purpose: 'find_email' },
       {
         onSuccess: () => setSmsSent(true),
-        onError: () => setPhoneError('SMS 발송에 실패했습니다.'),
+        onError: (error: unknown) => {
+          const axiosError = error as AxiosError<{
+            error_detail?: string | string[] | { phone_number?: string[] }
+          }>
+          const errorDetail = axiosError.response?.data?.error_detail
+          if (Array.isArray(errorDetail)) {
+            setPhoneError(errorDetail[0])
+          } else if (typeof errorDetail === 'string') {
+            setPhoneError(errorDetail)
+          } else if (errorDetail?.phone_number) {
+            setPhoneError(errorDetail.phone_number[0])
+          } else {
+            setPhoneError('SMS 발송에 실패했습니다.')
+          }
+        },
       }
     )
   }
@@ -120,7 +135,7 @@ export function FindEmailModal({
   }
 
   return (
-    <Modal isOpen={isOpen} onClose={handleClose}>
+    <Modal isOpen={isOpen} onClose={handleClose} closeOnOverlayClick={false}>
       {foundEmail ? (
         /* 성공 화면 */
         <div className="flex flex-col gap-4">

--- a/src/components/find/FindPasswordModal.tsx
+++ b/src/components/find/FindPasswordModal.tsx
@@ -201,7 +201,7 @@ export function FindPasswordModal({ isOpen, onClose }: FindPasswordModalProps) {
   }
 
   return (
-    <Modal isOpen={isOpen} onClose={handleClose}>
+    <Modal isOpen={isOpen} onClose={handleClose} closeOnOverlayClick={false}>
       {isSuccess ? (
         <div className="flex flex-col items-center gap-4 py-6">
           <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-100">


### PR DESCRIPTION
## 관련 이슈

- closes #120 

## 작업 내용

아이디 찾기 모달에서 휴대폰 인증번호 틀렸을 때 모달이 닫히는 현상 수정
비밀번호 찾기 모달에서 이메일 인증번호 틀렸을 때 모달이 닫히는 현상 수정

## 변경 사항

src/components/find/FindEmailModal.tsx
src/components/find/FindPasswordModal.tsx


## 스크린샷 (선택)

## 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다
- [ ] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [ ] 컨벤션에 맞게 작성했습니다
