### PR TITLE
fix: 헤더 커뮤니티/질의응답 버튼을 앵커 태그로 변경 (#122)

### DIFF
--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -66,18 +66,18 @@ export function Header({
               </button>
 
               <nav className="flex items-center gap-15">
-                <button
-                  onClick={() => navigate(ROUTES.COMMUNITY.LIST)}
+                <a
+                  href="https://community.ozcodingschool.site/"
                   className="hover:text-primary px-2.5 py-2.5 text-lg tracking-tight text-gray-900 transition-colors duration-150"
                 >
                   커뮤니티
-                </button>
-                <button
-                  onClick={() => navigate(ROUTES.QNA.LIST)}
+                </a>
+                <a
+                  href="https://qna.ozcodingschool.site/"
                   className="hover:text-primary px-2.5 py-2.5 text-lg tracking-tight text-gray-900 transition-colors duration-150"
                 >
                   질의응답
-                </button>
+                </a>
               </nav>
             </div>
 


### PR DESCRIPTION
## 관련 이슈

- closes #122 

## 작업 내용

-헤더 내비게이션의 커뮤니티·질의응답 항목을 `<button>` 에서 `<a>` 태그로 변경

## 변경 사항
- `src/components/layout/Header/Header.tsx`
   - 커뮤니티: `<button onClick={() => navigate(...)}>` → `<a href="https://community.ozcodingschool.site/">`
   - 질의응답: `<button onClick={() => navigate(...)}>` → `<a href="https://qna.ozcodingschool.site/">`

## 스크린샷 (선택)

## 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다
- [ ] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [ ] 컨벤션에 맞게 작성했습니다
